### PR TITLE
chore: update gatling-build-plugin to 4.2.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("net.moznion.sbt" % "sbt-spotless"          % "0.1.3")
-addSbtPlugin("io.gatling"      % "gatling-build-plugin"  % "4.1.0")
+addSbtPlugin("io.gatling"      % "gatling-build-plugin"  % "4.2.0")
 addSbtPlugin("net.aichler"     % "sbt-jupiter-interface" % "0.9.1")
 resolvers += Resolver.jcenterRepo


### PR DESCRIPTION
**Motivation:**
Update gatling-build-plugin to latest

**Modification:**
SBT Spotless was already configured on the project, so only upgrade gatling-build-pluginversion

**Ref:** MISC-308