### PR TITLE
feat: return simulation additionnaly to run summary on start simulation

### DIFF
--- a/src/main/java/io/gatling/plugin/util/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/util/EnterpriseClient.java
@@ -17,8 +17,8 @@
 package io.gatling.plugin.util;
 
 import io.gatling.plugin.util.exceptions.*;
-import io.gatling.plugin.util.model.RunSummary;
 import io.gatling.plugin.util.model.Simulation;
+import io.gatling.plugin.util.model.SimulationAndRunSummary;
 import java.io.File;
 import java.util.Map;
 import java.util.UUID;
@@ -56,7 +56,8 @@ public interface EnterpriseClient {
    * @param file Path to the packaged JAR file to upload and run; required
    * @throws SimulationNotFoundException if the simulationId does not exist
    */
-  RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties, File file)
+  SimulationAndRunSummary startSimulation(
+      UUID simulationId, Map<String, String> systemProperties, File file)
       throws EnterpriseClientException;
 
   /**

--- a/src/main/java/io/gatling/plugin/util/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/util/OkHttpEnterpriseClient.java
@@ -82,7 +82,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   }
 
   @Override
-  public RunSummary startSimulation(
+  public SimulationAndRunSummary startSimulation(
       UUID simulationId, Map<String, String> systemProperties, File file)
       throws EnterpriseClientException {
     nonNullParam(simulationId, "simulationId");
@@ -96,7 +96,9 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
 
     final Simulation simulation = simulationsApiRequests.getSimulation(simulationId);
     doUploadPackage(simulation.pkgId, file);
-    return simulationsApiRequests.startSimulation(simulationId, sysPropsList);
+    final RunSummary runSummary =
+        simulationsApiRequests.startSimulation(simulationId, sysPropsList);
+    return new SimulationAndRunSummary(simulation, runSummary);
   }
 
   @Override

--- a/src/main/java/io/gatling/plugin/util/model/SimulationAndRunSummary.java
+++ b/src/main/java/io/gatling/plugin/util/model/SimulationAndRunSummary.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util.model;
+
+import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
+
+import java.util.Objects;
+
+public class SimulationAndRunSummary {
+
+  public final Simulation simulation;
+  public final RunSummary runSummary;
+
+  public SimulationAndRunSummary(Simulation simulation, RunSummary runSummary) {
+    nonNullParam(simulation, "simulation");
+    nonNullParam(runSummary, "runSummary");
+    this.simulation = simulation;
+    this.runSummary = runSummary;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SimulationAndRunSummary that = (SimulationAndRunSummary) o;
+    return Objects.equals(simulation, that.simulation)
+        && Objects.equals(runSummary, that.runSummary);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(simulation, runSummary);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "SimulationAndRunSummary{simulation=%s, runSummary=%s}", simulation, runSummary);
+  }
+}


### PR DESCRIPTION
**Motivation:**
Simulation is fetch and may be needed by caller

**Modification:**
Add `SimulationAndRunSummary` POJO to hold both simulation and run summary, now returned by startSimulation