### PR TITLE
Upload checksum, closes MISC-293

### DIFF
--- a/src/main/java/io/gatling/plugin/util/PackagesApiRequests.java
+++ b/src/main/java/io/gatling/plugin/util/PackagesApiRequests.java
@@ -42,6 +42,20 @@ class PackagesApiRequests extends AbstractApiRequests {
     return executeRequest(request, response -> readResponseJson(response, Packages.class));
   }
 
+  Package readPackage(UUID packageId) throws EnterpriseClientException {
+    HttpUrl requestUrl =
+        url.newBuilder().addPathSegment("artifacts").addPathSegment(packageId.toString()).build();
+    Request.Builder request = new Request.Builder().url(requestUrl).get();
+    return executeRequest(
+        request,
+        response -> readResponseJson(response, Package.class),
+        response -> {
+          if (response.code() == HttpURLConnection.HTTP_NOT_FOUND) {
+            throw new PackageNotFoundException(packageId);
+          }
+        });
+  }
+
   Package createPackage(PackageCreationPayload pkg) throws EnterpriseClientException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("artifacts").build();
     RequestBody body = jsonRequestBody(pkg);

--- a/src/main/java/io/gatling/plugin/util/PkgChecksum.java
+++ b/src/main/java/io/gatling/plugin/util/PkgChecksum.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class PkgChecksum {
+
+  private static final String MANIFEST_NAME = "META-INF/MANIFEST.MF";
+
+  private PkgChecksum() {}
+
+  public static String computeChecksum(File file) throws IOException, NoSuchAlgorithmException {
+    MessageDigest md5 = MessageDigest.getInstance("MD5");
+
+    try (FileInputStream fis = new FileInputStream(file);
+        BufferedInputStream bis = new BufferedInputStream(fis);
+        ZipInputStream zis = new ZipInputStream(bis)) {
+
+      ZipEntry entry;
+      while ((entry = zis.getNextEntry()) != null) {
+        if (!entry.getName().equals(MANIFEST_NAME)) {
+          md5.update(BigInteger.valueOf(entry.getCrc()).toByteArray());
+        }
+      }
+    }
+
+    return Base64.getEncoder().encodeToString(md5.digest());
+  }
+}

--- a/src/main/java/io/gatling/plugin/util/model/Package.java
+++ b/src/main/java/io/gatling/plugin/util/model/Package.java
@@ -30,20 +30,20 @@ public final class Package {
 
   public final String name;
   /** Optional. */
-  public final String fileName;
+  public final PackageFile file;
 
   @JsonCreator
   public Package(
       @JsonProperty(value = "id", required = true) UUID id,
       @JsonProperty(value = "teamId") UUID teamId,
       @JsonProperty(value = "name", required = true) String name,
-      @JsonProperty(value = "fileName") String fileName) {
+      @JsonProperty(value = "file") PackageFile file) {
     nonNullParam(id, "id");
     nonNullParam(name, "name");
     this.id = id;
     this.teamId = teamId;
     this.name = name;
-    this.fileName = fileName;
+    this.file = file;
   }
 
   @Override
@@ -54,17 +54,17 @@ public final class Package {
     return id.equals(aPackage.id)
         && Objects.equals(teamId, aPackage.teamId)
         && name.equals(aPackage.name)
-        && Objects.equals(fileName, aPackage.fileName);
+        && Objects.equals(file, aPackage.file);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, teamId, name, fileName);
+    return Objects.hash(id, teamId, name, file);
   }
 
   @Override
   public String toString() {
     return String.format(
-        "Package{id='%s',teamId='%s',name='%s',fileName='%s'}", id, teamId, name, fileName);
+        "Package{id='%s',teamId='%s',name='%s',file='%s'}", id, teamId, name, file);
   }
 }

--- a/src/main/java/io/gatling/plugin/util/model/PackageFile.java
+++ b/src/main/java/io/gatling/plugin/util/model/PackageFile.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public final class PackageFile {
+
+  public final String filename;
+
+  public final String version;
+
+  public final String checksum;
+
+  public PackageFile(
+      @JsonProperty(value = "filename") String filename,
+      @JsonProperty(value = "version") String version,
+      @JsonProperty(value = "checksum") String checksum) {
+    this.filename = filename;
+    this.version = version;
+    this.checksum = checksum;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "PackageFile{filename='%s',version='%s',checksum='%s'}", filename, version, checksum);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PackageFile that = (PackageFile) o;
+    return Objects.equals(filename, that.filename)
+        && Objects.equals(version, that.version)
+        && Objects.equals(checksum, that.checksum);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(filename, version, checksum);
+  }
+}

--- a/src/main/java/io/gatling/plugin/util/model/PackageIndex.java
+++ b/src/main/java/io/gatling/plugin/util/model/PackageIndex.java
@@ -20,33 +20,51 @@ import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
-public final class Packages {
-  public final List<PackageIndex> data;
+public final class PackageIndex {
+  public final UUID id;
+  /** Optional. */
+  public final UUID teamId;
+
+  public final String name;
+  /** Optional. */
+  public final String fileName;
 
   @JsonCreator
-  public Packages(@JsonProperty(value = "data", required = true) List<PackageIndex> data) {
-    nonNullParam(data, "data");
-    this.data = data;
+  public PackageIndex(
+      @JsonProperty(value = "id", required = true) UUID id,
+      @JsonProperty(value = "teamId") UUID teamId,
+      @JsonProperty(value = "name", required = true) String name,
+      @JsonProperty(value = "fileName") String fileName) {
+    nonNullParam(id, "id");
+    nonNullParam(name, "name");
+    this.id = id;
+    this.teamId = teamId;
+    this.name = name;
+    this.fileName = fileName;
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    Packages packages = (Packages) o;
-    return data.equals(packages.data);
+    PackageIndex aPackage = (PackageIndex) o;
+    return id.equals(aPackage.id)
+        && Objects.equals(teamId, aPackage.teamId)
+        && name.equals(aPackage.name)
+        && Objects.equals(fileName, aPackage.fileName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(data);
+    return Objects.hash(id, teamId, name, fileName);
   }
 
   @Override
   public String toString() {
-    return String.format("Packages{data=%s}", data);
+    return String.format(
+        "Package{id='%s',teamId='%s',name='%s',fileName='%s'}", id, teamId, name, fileName);
   }
 }

--- a/src/test/java/io/gatling/plugin/util/model/JsonUnmarshallingTest.java
+++ b/src/test/java/io/gatling/plugin/util/model/JsonUnmarshallingTest.java
@@ -36,17 +36,17 @@ public class JsonUnmarshallingTest {
     final Packages expected =
         new Packages(
             Arrays.asList(
-                new Package(
+                new PackageIndex(
                     UUID.fromString("c0074b5a-5b97-4fbb-bad9-b3848bac3082"),
                     null,
                     "First package",
                     null),
-                new Package(
+                new PackageIndex(
                     UUID.fromString("44191a0c-2e15-49b3-8876-7aa47cc97587"),
                     UUID.fromString("40084389-c812-42c1-aaef-f8730959510c"),
                     "Second package",
                     null),
-                new Package(
+                new PackageIndex(
                     UUID.fromString("0cf26226-b261-4af6-a52a-1fec36f4394a"),
                     UUID.fromString("c5f9e46c-3860-4d95-a851-db0814bdd360"),
                     "Third package",


### PR DESCRIPTION
chore: use package index class in packages response
---

feat: add api request to fetch a single package 
---

**Motivation:**
Used to compare package checksum with next upload package checksum

feat: compare checksum before uploading 
---

**Motivation:**
We don't wan't to upload a package if it haven't have changed

**Modification:**
Fetch package, if exist compute current checksum and compare, skip upload if equals
