### PR TITLE
fix: checksum computation failed based on CRC

### DIFF
--- a/src/main/java/io/gatling/plugin/util/checksum/PkgChecksum.java
+++ b/src/main/java/io/gatling/plugin/util/checksum/PkgChecksum.java
@@ -42,6 +42,7 @@ public class PkgChecksum {
         ZipEntry entry;
         while ((entry = zis.getNextEntry()) != null) {
           if (!entry.getName().equals(MANIFEST_NAME)) {
+            zis.closeEntry();
             md5.update(BigInteger.valueOf(entry.getCrc()).toByteArray());
           }
         }


### PR DESCRIPTION
**Motivation:**
Checksum does not change while files does

**Modifications:**
getCrc always return -1 until stream close entry is called.