### PR TITLE
Add the option to upload package with the simulationId if there is no packageId

### DIFF
--- a/src/main/java/io/gatling/plugin/EnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePlugin.java
@@ -38,12 +38,20 @@ import java.util.UUID;
 public interface EnterprisePlugin {
 
   /**
-   * Upload file to the package associated with given ID
+   * Upload file to the package associated with given packageId
    *
    * @param packageId Required
    * @param file Path to the packaged JAR file to upload and run; required
    */
   long uploadPackage(UUID packageId, File file) throws EnterpriseClientException;
+
+  /**
+   * Upload file to the package associated to the given simulationId
+   *
+   * @param simulationId Required
+   * @param file Path to the packaged JAR file to upload and run; required
+   */
+  long uploadPackageWithSimulationId(UUID simulationId, File file) throws EnterpriseClientException;
 
   /**
    * Upload file to the package configured on the given simulation ID, and start the simulation

--- a/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
@@ -33,10 +33,20 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
   }
 
   @Override
-  public long uploadPackage(UUID packageId, File file) throws EnterpriseClientException {
-    nonNullParam(packageId, "packageId");
+  public long uploadPackage(UUID packageId, File file)
+      throws EnterpriseClientException {
+    nonNullParam(file, "packageId");
     nonNullParam(file, "file");
     return enterpriseClient.uploadPackageWithChecksum(packageId, file);
+  }
+
+  @Override
+  public long uploadPackageWithSimulationId(UUID simulationId, File file)
+      throws EnterpriseClientException {
+    nonNullParam(file, "simulationId");
+    nonNullParam(file, "file");
+    Simulation simulation = enterpriseClient.getSimulation(simulationId);
+    return enterpriseClient.uploadPackageWithChecksum(simulation.pkgId, file);
   }
 
   @Override


### PR DESCRIPTION
Motivation:
- With the new start command, we should only use simulationId, and no longer packageId

Modification:
- if the packageId is missing, try to upload the file with the simulation's package

ref: MISC-322