### PR TITLE
Improve enterpriseStart input choices UX, closes MISC-321

### DIFF
--- a/src/main/java/io/gatling/plugin/EnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePlugin.java
@@ -16,7 +16,7 @@
 
 package io.gatling.plugin;
 
-import io.gatling.plugin.client.exceptions.*;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.model.SimulationStartResult;
 import java.io.File;
 import java.util.Map;
@@ -25,7 +25,7 @@ import java.util.UUID;
 /**
  * Enterprise plugin features
  *
- * <p>The following exception sub-classes of {@link EnterpriseClientException} can be thrown by all
+ * <p>The following exception sub-classes of {@link EnterprisePluginException} can be thrown by all
  * methods of this client:
  *
  * <ul>
@@ -43,7 +43,7 @@ public interface EnterprisePlugin {
    * @param packageId Required
    * @param file Path to the packaged JAR file to upload and run; required
    */
-  long uploadPackage(UUID packageId, File file) throws EnterpriseClientException;
+  long uploadPackage(UUID packageId, File file) throws EnterprisePluginException;
 
   /**
    * Upload file to the package associated to the given simulationId
@@ -51,7 +51,7 @@ public interface EnterprisePlugin {
    * @param simulationId Required
    * @param file Path to the packaged JAR file to upload and run; required
    */
-  long uploadPackageWithSimulationId(UUID simulationId, File file) throws EnterpriseClientException;
+  long uploadPackageWithSimulationId(UUID simulationId, File file) throws EnterprisePluginException;
 
   /**
    * Upload file to the package configured on the given simulation ID, and start the simulation
@@ -63,7 +63,7 @@ public interface EnterprisePlugin {
    */
   SimulationStartResult uploadPackageAndStartSimulation(
       UUID simulationId, Map<String, String> systemProperties, File file)
-      throws EnterpriseClientException;
+      throws EnterprisePluginException;
 
   /**
    * Create and start a simulation with given parameters
@@ -84,5 +84,5 @@ public interface EnterprisePlugin {
       UUID packageId,
       Map<String, String> systemProperties,
       File file)
-      throws EnterpriseClientException;
+      throws EnterprisePluginException;
 }

--- a/src/main/java/io/gatling/plugin/EnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePlugin.java
@@ -75,6 +75,7 @@ public interface EnterprisePlugin {
    * @param packageId Optional
    * @param systemProperties Required, can be an empty Map
    * @param file Required
+   * @throws SimulationStartException if simulation start failed after creation
    */
   SimulationStartResult createAndStartSimulation(
       UUID teamId,

--- a/src/main/java/io/gatling/plugin/EnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePlugin.java
@@ -17,7 +17,7 @@
 package io.gatling.plugin;
 
 import io.gatling.plugin.client.exceptions.*;
-import io.gatling.plugin.model.SimulationAndRunSummary;
+import io.gatling.plugin.model.SimulationStartResult;
 import java.io.File;
 import java.util.Map;
 import java.util.UUID;
@@ -61,7 +61,7 @@ public interface EnterprisePlugin {
    * @param file Required, Path to the packaged JAR file to upload and run
    * @throws SimulationNotFoundException if the simulationId does not exist
    */
-  SimulationAndRunSummary uploadPackageAndStartSimulation(
+  SimulationStartResult uploadPackageAndStartSimulation(
       UUID simulationId, Map<String, String> systemProperties, File file)
       throws EnterpriseClientException;
 
@@ -71,13 +71,17 @@ public interface EnterprisePlugin {
    * @param teamId Optional
    * @param groupId Optional
    * @param artifactId Required
-   * @param className Required
+   * @param simulationClass Required
+   * @param packageId Optional
+   * @param systemProperties Required, can be an empty Map
+   * @param file Required
    */
-  SimulationAndRunSummary createAndStartSimulation(
+  SimulationStartResult createAndStartSimulation(
       UUID teamId,
       String groupId,
       String artifactId,
-      String className,
+      String simulationClass,
+      UUID packageId,
       Map<String, String> systemProperties,
       File file)
       throws EnterpriseClientException;

--- a/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
@@ -136,7 +136,12 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
 
     final Simulation simulation =
         enterpriseClient.createSimulation(simulationName, team.id, className, pkg.id, hostsByPool);
-    final RunSummary runSummary = enterpriseClient.startSimulation(simulation.id, systemProperties);
-    return new SimulationStartResult(simulation, runSummary, true);
+    try {
+      final RunSummary runSummary =
+          enterpriseClient.startSimulation(simulation.id, systemProperties);
+      return new SimulationStartResult(simulation, runSummary, true);
+    } catch (EnterprisePluginException e) {
+      throw new SimulationStartException(simulation, e);
+    }
   }
 }

--- a/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
@@ -20,7 +20,7 @@ import static io.gatling.plugin.util.ObjectsUtil.nonEmptyParam;
 import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import io.gatling.plugin.client.EnterpriseClient;
-import io.gatling.plugin.client.exceptions.*;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.model.*;
 import io.gatling.plugin.model.Pkg;
 import java.io.File;
@@ -33,7 +33,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
   }
 
   @Override
-  public long uploadPackage(UUID packageId, File file) throws EnterpriseClientException {
+  public long uploadPackage(UUID packageId, File file) throws EnterprisePluginException {
     nonNullParam(packageId, "packageId");
     nonNullParam(file, "file");
     return enterpriseClient.uploadPackageWithChecksum(packageId, file);
@@ -41,7 +41,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
 
   @Override
   public long uploadPackageWithSimulationId(UUID simulationId, File file)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     nonNullParam(file, "simulationId");
     nonNullParam(file, "file");
     Simulation simulation = enterpriseClient.getSimulation(simulationId);
@@ -51,7 +51,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
   @Override
   public SimulationStartResult uploadPackageAndStartSimulation(
       UUID simulationId, Map<String, String> systemProperties, File file)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     nonNullParam(simulationId, "simulationId");
     nonNullParam(systemProperties, "systemProperties");
     nonNullParam(file, "file");
@@ -71,7 +71,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
       UUID packageId,
       Map<String, String> systemProperties,
       File file)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     nonEmptyParam(artifactId, "artifactId");
     nonEmptyParam(simulationClass, "className");
 
@@ -84,7 +84,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
     return createAndStartSimulation(team, pkg, simulationClass, hostsByPool, systemProperties);
   }
 
-  private Team defaultTeam(UUID teamId) throws EnterpriseClientException {
+  private Team defaultTeam(UUID teamId) throws EnterprisePluginException {
     final List<Team> teams = enterpriseClient.getTeams();
     if (teams.isEmpty()) {
       throw new IllegalStateException(
@@ -106,14 +106,14 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
   }
 
   private Pkg createAndUploadDefaultPackage(Team team, String groupId, String artifactId, File file)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     final String packageName = groupId != null ? groupId + ":" + artifactId : artifactId;
     final Pkg pkg = enterpriseClient.createPackage(packageName, team.id);
     enterpriseClient.uploadPackage(pkg.id, file);
     return pkg;
   }
 
-  private Map<UUID, HostByPool> defaultHostByPool() throws EnterpriseClientException {
+  private Map<UUID, HostByPool> defaultHostByPool() throws EnterprisePluginException {
     final List<Pool> pools = enterpriseClient.getPools();
     if (pools.isEmpty()) {
       // Should never happen on Gatling Enterprise Cloud
@@ -130,7 +130,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
       String className,
       Map<UUID, HostByPool> hostsByPool,
       Map<String, String> systemProperties)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     final String[] classNameParts = className.split("\\.");
     final String simulationName = classNameParts[classNameParts.length - 1];
 

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePlugin.java
@@ -17,7 +17,7 @@
 package io.gatling.plugin;
 
 import io.gatling.plugin.client.exceptions.*;
-import io.gatling.plugin.model.SimulationAndRunSummary;
+import io.gatling.plugin.model.SimulationStartResult;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -45,22 +45,25 @@ public interface InteractiveEnterprisePlugin {
   /**
    * Create and start a simulation with given parameters
    *
-   * @param teamId Optional, if not null and the team exists, will be automatically pick
+   * @param teamId Optional, if not null, will be automatically picked
    * @param groupId Optional, if not null, will prefix the proposed package name
    * @param artifactId Optional, if not null, will suffix the proposed package name
-   * @param className Optional, if not null, will be added to the list of available classNames
-   * @param classNames Required, the list of potential Simulation class names in the project,
-   *     required
+   * @param simulationClass Optional, if not null, will be automatically picked
+   * @param discoveredSimulationClasses Required, the list of potential simulation classes in the
+   *     project, required
+   * @param packageId Optional, if not null, will be automatically picked when creating a new
+   *     simulation
    * @param systemProperties Required, can be an empty map; override conflicting system properties
    *     when running the simulation
    * @param file Required, path to the packaged JAR file to upload and run
    */
-  SimulationAndRunSummary createOrStartSimulation(
+  SimulationStartResult createOrStartSimulation(
       UUID teamId,
       String groupId,
       String artifactId,
-      String className,
-      List<String> classNames,
+      String simulationClass,
+      List<String> discoveredSimulationClasses,
+      UUID packageId,
       Map<String, String> systemProperties,
       File file)
       throws EnterpriseClientException, EmptyChoicesException;

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePlugin.java
@@ -16,7 +16,7 @@
 
 package io.gatling.plugin;
 
-import io.gatling.plugin.client.exceptions.*;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.model.SimulationStartResult;
 import java.io.File;
 import java.util.List;
@@ -30,7 +30,7 @@ import java.util.UUID;
  * <p>All methods can throw an {@link EmptyChoicesException} if the API returns an empty set of
  * available choices.
  *
- * <p>The following exception sub-classes of {@link EnterpriseClientException} can be thrown by all
+ * <p>The following exception sub-classes of {@link EnterprisePluginException} can be thrown by all
  * methods of this client:
  *
  * <ul>
@@ -66,5 +66,5 @@ public interface InteractiveEnterprisePlugin {
       UUID packageId,
       Map<String, String> systemProperties,
       File file)
-      throws EnterpriseClientException, EmptyChoicesException;
+      throws EnterprisePluginException, EmptyChoicesException;
 }

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePlugin.java
@@ -56,6 +56,7 @@ public interface InteractiveEnterprisePlugin {
    * @param systemProperties Required, can be an empty map; override conflicting system properties
    *     when running the simulation
    * @param file Required, path to the packaged JAR file to upload and run
+   * @throws SimulationStartException if simulation start failed after creation
    */
   SimulationStartResult createOrStartSimulation(
       UUID teamId,

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
@@ -20,6 +20,7 @@ import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import io.gatling.plugin.client.EnterpriseClient;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.exceptions.SimulationStartException;
 import io.gatling.plugin.io.PluginIO;
 import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.io.input.InputChoice;
@@ -147,9 +148,12 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
         enterpriseClient.createSimulation(
             simulationName, team.id, simulationClass, pkg.id, hostsByPool);
 
-    RunSummary runSummary = enterpriseClient.startSimulation(simulation.id, systemProperties);
-
-    return new SimulationStartResult(simulation, runSummary, true);
+    try {
+      RunSummary runSummary = enterpriseClient.startSimulation(simulation.id, systemProperties);
+      return new SimulationStartResult(simulation, runSummary, true);
+    } catch (EnterprisePluginException e) {
+      throw new SimulationStartException(simulation, e);
+    }
   }
 
   private String chooseSimulationClass(

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
@@ -19,7 +19,7 @@ package io.gatling.plugin;
 import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import io.gatling.plugin.client.EnterpriseClient;
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.io.PluginIO;
 import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.io.input.InputChoice;
@@ -53,7 +53,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
       UUID configuredPackageId,
       Map<String, String> systemProperties,
       File file)
-      throws EnterpriseClientException, EmptyChoicesException {
+      throws EnterprisePluginException, EmptyChoicesException {
     nonNullParam(discoveredSimulationClasses, "discoveredSimulationClasses");
     nonNullParam(systemProperties, "systemProperties");
     nonNullParam(file, "file");
@@ -83,7 +83,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
     return inputChoice.inputFromStringList(choices, false).equals(create);
   }
 
-  private void uploadPackage(UUID artifactId, File packageFile) throws EnterpriseClientException {
+  private void uploadPackage(UUID artifactId, File packageFile) throws EnterprisePluginException {
     logger.info("Uploading package...");
     enterpriseClient.uploadPackage(artifactId, packageFile);
     logger.info("Package uploaded");
@@ -91,7 +91,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
 
   private SimulationStartResult startSimulation(
       File packageFile, Map<String, String> systemProperties, List<Simulation> simulations)
-      throws EnterpriseClientException, EmptyChoicesException {
+      throws EnterprisePluginException, EmptyChoicesException {
     logger.info("Proceeding to start simulation");
 
     if (simulations.isEmpty()) {
@@ -128,7 +128,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
       File packageFile,
       List<Simulation> existingSimulations,
       Map<String, String> systemProperties)
-      throws EnterpriseClientException, EmptyChoicesException {
+      throws EnterprisePluginException, EmptyChoicesException {
     logger.info("Proceeding to the create simulation step");
     String simulationClass =
         chooseSimulationClass(configuredSimulationClass, discoveredSimulationClasses);
@@ -173,7 +173,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
 
   /** @param configuredTeamId Optional */
   private Team chooseTeam(UUID configuredTeamId)
-      throws EnterpriseClientException, EmptyChoicesException {
+      throws EnterprisePluginException, EmptyChoicesException {
     final List<Team> teams = enterpriseClient.getTeams();
 
     if (configuredTeamId != null) {
@@ -240,7 +240,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
    */
   private Pkg chooseOrCreatePackage(
       UUID teamId, String groupId, String artifactId, UUID configuredPackageId)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     final List<PkgIndex> existingPackages = enterpriseClient.getPackages();
 
     if (configuredPackageId != null) {
@@ -271,7 +271,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
     return inputChoice.inputFromStringList(choices, false).equals(create);
   }
 
-  private Pkg choosePackage(List<PkgIndex> existingPackages) throws EnterpriseClientException {
+  private Pkg choosePackage(List<PkgIndex> existingPackages) throws EnterprisePluginException {
     logger.info("Choose a package from the list:");
     final UUID packageId =
         inputChoice.inputFromList(
@@ -282,7 +282,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
 
   private Pkg createPackage(
       UUID teamId, String groupId, String artifactId, List<PkgIndex> existingPackages)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     final String defaultPackageName =
         artifactId != null ? (groupId != null ? groupId + ":" + artifactId : artifactId) : null;
     final Set<String> existingPackageNames =
@@ -313,7 +313,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
     return enterpriseClient.createPackage(packageName, teamId);
   }
 
-  private Pool choosePool() throws EnterpriseClientException, EmptyChoicesException {
+  private Pool choosePool() throws EnterprisePluginException, EmptyChoicesException {
     final List<Pool> pools = enterpriseClient.getPools();
 
     if (pools.isEmpty()) {

--- a/src/main/java/io/gatling/plugin/Show.java
+++ b/src/main/java/io/gatling/plugin/Show.java
@@ -31,4 +31,8 @@ public final class Show {
   static String pool(Pool pool) {
     return "Pool " + pool.name;
   }
+
+  static String packageIndex(PkgIndex pkg) {
+    return String.format("Package '%s', id='%s'", pkg.name, pkg.id);
+  }
 }

--- a/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
@@ -58,10 +58,10 @@ public interface EnterpriseClient {
   /**
    * @param simulationId Required
    * @param systemProperties Required (can be an empty map)
-   * @throws SimulationNotFoundException if the simulationId does not exist
+   * @throws SimulationStartException when start failed for any reason
    */
   RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties)
-      throws EnterpriseClientException;
+      throws EnterprisePluginException;
 
   long uploadPackageWithChecksum(UUID packageId, File file) throws EnterprisePluginException;
 

--- a/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
@@ -16,7 +16,7 @@
 
 package io.gatling.plugin.client;
 
-import io.gatling.plugin.client.exceptions.*;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.model.*;
 import java.io.File;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * The following exception sub-classes of {@link EnterpriseClientException} can be thrown by all
+ * The following exception sub-classes of {@link EnterprisePluginException} can be thrown by all
  * methods of this public API:
  *
  * <ul>
@@ -36,24 +36,24 @@ import java.util.UUID;
  */
 public interface EnterpriseClient {
 
-  List<Simulation> getSimulations() throws EnterpriseClientException;
+  List<Simulation> getSimulations() throws EnterprisePluginException;
 
-  public Simulation getSimulation(UUID simulationId) throws EnterpriseClientException;
+  public Simulation getSimulation(UUID simulationId) throws EnterprisePluginException;
 
-  public List<Team> getTeams() throws EnterpriseClientException;
+  public List<Team> getTeams() throws EnterprisePluginException;
 
-  public List<Pool> getPools() throws EnterpriseClientException;
+  public List<Pool> getPools() throws EnterprisePluginException;
 
-  List<PkgIndex> getPackages() throws EnterpriseClientException;
+  List<PkgIndex> getPackages() throws EnterprisePluginException;
 
-  public Pkg getPackage(UUID pkgId) throws EnterpriseClientException;
+  public Pkg getPackage(UUID pkgId) throws EnterprisePluginException;
 
   /**
    * @param packageId Required
    * @param file Path to the packaged JAR file to upload; required
    * @throws PackageNotFoundException if the packageId does not exist
    */
-  long uploadPackage(UUID packageId, File file) throws EnterpriseClientException;
+  long uploadPackage(UUID packageId, File file) throws EnterprisePluginException;
 
   /**
    * @param simulationId Required
@@ -63,7 +63,7 @@ public interface EnterpriseClient {
   RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties)
       throws EnterpriseClientException;
 
-  long uploadPackageWithChecksum(UUID packageId, File file) throws EnterpriseClientException;
+  long uploadPackageWithChecksum(UUID packageId, File file) throws EnterprisePluginException;
 
   Simulation createSimulation(
       String simulationName,
@@ -71,7 +71,7 @@ public interface EnterpriseClient {
       String className,
       UUID pkgId,
       Map<UUID, HostByPool> hostsByPool)
-      throws EnterpriseClientException;
+      throws EnterprisePluginException;
 
-  Pkg createPackage(String packageName, UUID teamId) throws EnterpriseClientException;
+  Pkg createPackage(String packageName, UUID teamId) throws EnterprisePluginException;
 }

--- a/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
@@ -44,7 +44,7 @@ public interface EnterpriseClient {
 
   public List<Pool> getPools() throws EnterpriseClientException;
 
-  List<PackageIndex> getPackages() throws EnterpriseClientException;
+  List<PkgIndex> getPackages() throws EnterpriseClientException;
 
   public Pkg getPackage(UUID pkgId) throws EnterpriseClientException;
 

--- a/src/main/java/io/gatling/plugin/client/exceptions/ForbiddenApiCallException.java
+++ b/src/main/java/io/gatling/plugin/client/exceptions/ForbiddenApiCallException.java
@@ -19,6 +19,6 @@ package io.gatling.plugin.client.exceptions;
 public final class ForbiddenApiCallException extends EnterpriseClientException {
   public ForbiddenApiCallException() {
     super(
-        "API token valid but lacks required privileges: please configure a token with the role 'All' (see https://gatling.io/docs/enterprise/cloud/reference/admin/api_tokens/)");
+        "API token valid but lacks required privileges: please configure a token with the role 'Configure' (see https://gatling.io/docs/enterprise/cloud/reference/admin/api_tokens/)");
   }
 }

--- a/src/main/java/io/gatling/plugin/client/http/AbstractApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/AbstractApiRequests.java
@@ -20,7 +20,7 @@ import static io.gatling.plugin.client.json.JsonUtil.JSON_MAPPER;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.gatling.plugin.client.exceptions.*;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.util.LambdaExceptionUtil;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -52,11 +52,11 @@ abstract class AbstractApiRequests {
 
   <T> T executeRequest(
       Request.Builder unauthenticatedRequest,
-      LambdaExceptionUtil.FunctionWithExceptions<Response, T, EnterpriseClientException>
+      LambdaExceptionUtil.FunctionWithExceptions<Response, T, EnterprisePluginException>
           handleSuccessfulResponse,
-      LambdaExceptionUtil.ConsumerWithExceptions<Response, EnterpriseClientException>
+      LambdaExceptionUtil.ConsumerWithExceptions<Response, EnterprisePluginException>
           validateResponse)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     Request request = unauthenticatedRequest.header(AUTHORIZATION_HEADER, token).build();
     try (Response response = okHttpClient.newCall(request).execute()) {
       validateResponse.accept(response);
@@ -69,13 +69,13 @@ abstract class AbstractApiRequests {
 
   <T> T executeRequest(
       Request.Builder unauthenticatedRequest,
-      LambdaExceptionUtil.FunctionWithExceptions<Response, T, EnterpriseClientException>
+      LambdaExceptionUtil.FunctionWithExceptions<Response, T, EnterprisePluginException>
           handleSuccessfulResponse)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     return executeRequest(unauthenticatedRequest, handleSuccessfulResponse, response -> {});
   }
 
-  void defaultValidateResponse(Response response) throws EnterpriseClientException {
+  void defaultValidateResponse(Response response) throws EnterprisePluginException {
     if (!response.isSuccessful()) {
       switch (response.code()) {
         case HttpURLConnection.HTTP_UNAUTHORIZED:
@@ -90,7 +90,7 @@ abstract class AbstractApiRequests {
     }
   }
 
-  String readResponseBody(Response response) throws EnterpriseClientException {
+  String readResponseBody(Response response) throws EnterprisePluginException {
     try (ResponseBody body = response.body()) {
       return body.string();
     } catch (IOException e) {
@@ -98,7 +98,7 @@ abstract class AbstractApiRequests {
     }
   }
 
-  <T> T readResponseJson(Response response, Class<T> valueType) throws EnterpriseClientException {
+  <T> T readResponseJson(Response response, Class<T> valueType) throws EnterprisePluginException {
     try {
       return JSON_MAPPER.readValue(readResponseBody(response), valueType);
     } catch (JsonProcessingException e) {
@@ -107,7 +107,7 @@ abstract class AbstractApiRequests {
   }
 
   <T> T readResponseJson(Response response, TypeReference<T> valueTypeRef)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     try {
       return JSON_MAPPER.readValue(readResponseBody(response), valueTypeRef);
     } catch (JsonProcessingException e) {

--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -22,7 +22,6 @@ import io.gatling.plugin.client.EnterpriseClient;
 import io.gatling.plugin.exceptions.ApiCallIOException;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.exceptions.PackageNotFoundException;
-import io.gatling.plugin.exceptions.SimulationStartException;
 import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.model.*;
 import io.gatling.plugin.util.checksum.PkgChecksum;
@@ -119,7 +118,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
 
   @Override
   public RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
 
     final List<SystemProperty> sysPropsList =
         systemProperties.entrySet().stream()

--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -102,7 +102,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   }
 
   @Override
-  public List<PackageIndex> getPackages() throws EnterpriseClientException {
+  public List<PkgIndex> getPackages() throws EnterpriseClientException {
     return packagesApiRequests.listPackages().data;
   }
 

--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -19,9 +19,10 @@ package io.gatling.plugin.client.http;
 import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import io.gatling.plugin.client.EnterpriseClient;
-import io.gatling.plugin.client.exceptions.ApiCallIOException;
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
-import io.gatling.plugin.client.exceptions.PackageNotFoundException;
+import io.gatling.plugin.exceptions.ApiCallIOException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.exceptions.PackageNotFoundException;
+import io.gatling.plugin.exceptions.SimulationStartException;
 import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.model.*;
 import io.gatling.plugin.util.checksum.PkgChecksum;
@@ -51,7 +52,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
       String token,
       String client,
       String version)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     OkHttpEnterpriseClient enterpriseClient =
         new OkHttpEnterpriseClient(logger, okHttpClient, url, token);
     enterpriseClient.privateApiRequests.checkVersionSupport(client, version);
@@ -60,7 +61,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
 
   public static OkHttpEnterpriseClient getInstance(
       PluginLogger logger, URL url, String token, String client, String version)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     return getInstance(logger, new OkHttpClient(), url, token, client, version);
   }
 
@@ -82,37 +83,37 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   }
 
   @Override
-  public List<Simulation> getSimulations() throws EnterpriseClientException {
+  public List<Simulation> getSimulations() throws EnterprisePluginException {
     return simulationsApiRequests.listSimulations().data;
   }
 
   @Override
-  public Simulation getSimulation(UUID simulationId) throws EnterpriseClientException {
+  public Simulation getSimulation(UUID simulationId) throws EnterprisePluginException {
     return simulationsApiRequests.getSimulation(simulationId);
   }
 
   @Override
-  public List<Team> getTeams() throws EnterpriseClientException {
+  public List<Team> getTeams() throws EnterprisePluginException {
     return teamsApiRequests.listTeams().data;
   }
 
   @Override
-  public List<Pool> getPools() throws EnterpriseClientException {
+  public List<Pool> getPools() throws EnterprisePluginException {
     return poolsApiRequests.listPools().data;
   }
 
   @Override
-  public List<PkgIndex> getPackages() throws EnterpriseClientException {
+  public List<PkgIndex> getPackages() throws EnterprisePluginException {
     return packagesApiRequests.listPackages().data;
   }
 
   @Override
-  public Pkg getPackage(UUID pkgId) throws EnterpriseClientException {
+  public Pkg getPackage(UUID pkgId) throws EnterprisePluginException {
     return packagesApiRequests.readPackage(pkgId);
   }
 
   @Override
-  public long uploadPackage(UUID packageId, File file) throws EnterpriseClientException {
+  public long uploadPackage(UUID packageId, File file) throws EnterprisePluginException {
     return packagesApiRequests.uploadPackage(packageId, file);
   }
 
@@ -128,7 +129,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
     return simulationsApiRequests.startSimulation(simulationId, sysPropsList);
   }
 
-  private boolean checksumComparison(UUID packageId, File file) throws EnterpriseClientException {
+  private boolean checksumComparison(UUID packageId, File file) throws EnterprisePluginException {
     try {
       Pkg pkg = getPackage(packageId);
       return pkg.file != null && PkgChecksum.computeChecksum(file).equals(pkg.file.checksum);
@@ -141,7 +142,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
 
   @Override
   public long uploadPackageWithChecksum(UUID packageId, File file)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     if (checksumComparison(packageId, file)) {
       logger.info("No code changes detected, skipping package upload");
       return file.length();
@@ -157,7 +158,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
       String className,
       UUID pkgId,
       Map<UUID, HostByPool> hostsByPool)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     return simulationsApiRequests.createSimulation(
         new SimulationCreationPayload(
             simulationName,
@@ -174,7 +175,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   }
 
   @Override
-  public Pkg createPackage(String packageName, UUID teamId) throws EnterpriseClientException {
+  public Pkg createPackage(String packageName, UUID teamId) throws EnterprisePluginException {
     return packagesApiRequests.createPackage(new PackageCreationPayload(packageName, teamId));
   }
 }

--- a/src/main/java/io/gatling/plugin/client/http/PackagesApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/PackagesApiRequests.java
@@ -16,9 +16,9 @@
 
 package io.gatling.plugin.client.http;
 
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
-import io.gatling.plugin.client.exceptions.InvalidApiCallException;
-import io.gatling.plugin.client.exceptions.PackageNotFoundException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.exceptions.InvalidApiCallException;
+import io.gatling.plugin.exceptions.PackageNotFoundException;
 import io.gatling.plugin.model.*;
 import java.io.File;
 import java.net.HttpURLConnection;
@@ -34,13 +34,13 @@ class PackagesApiRequests extends AbstractApiRequests {
     super(okHttpClient, url, token);
   }
 
-  Packages listPackages() throws EnterpriseClientException {
+  Packages listPackages() throws EnterprisePluginException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("artifacts").build();
     Request.Builder request = new Request.Builder().url(requestUrl).get();
     return executeRequest(request, response -> readResponseJson(response, Packages.class));
   }
 
-  Pkg readPackage(UUID packageId) throws EnterpriseClientException {
+  Pkg readPackage(UUID packageId) throws EnterprisePluginException {
     HttpUrl requestUrl =
         url.newBuilder().addPathSegment("artifacts").addPathSegment(packageId.toString()).build();
     Request.Builder request = new Request.Builder().url(requestUrl).get();
@@ -54,14 +54,14 @@ class PackagesApiRequests extends AbstractApiRequests {
         });
   }
 
-  Pkg createPackage(PackageCreationPayload pkg) throws EnterpriseClientException {
+  Pkg createPackage(PackageCreationPayload pkg) throws EnterprisePluginException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("artifacts").build();
     RequestBody body = jsonRequestBody(pkg);
     Request.Builder request = new Request.Builder().url(requestUrl).post(body);
     return executeRequest(request, response -> readResponseJson(response, Pkg.class));
   }
 
-  long uploadPackage(UUID packageId, File file) throws EnterpriseClientException {
+  long uploadPackage(UUID packageId, File file) throws EnterprisePluginException {
     Request.Builder request = uploadPackageRequest(packageId, file);
     return executeRequest(
         request,

--- a/src/main/java/io/gatling/plugin/client/http/PoolsApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/PoolsApiRequests.java
@@ -16,7 +16,7 @@
 
 package io.gatling.plugin.client.http;
 
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.model.Pools;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -27,7 +27,7 @@ class PoolsApiRequests extends AbstractApiRequests {
     super(okHttpClient, url, token);
   }
 
-  Pools listPools() throws EnterpriseClientException {
+  Pools listPools() throws EnterprisePluginException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("pools").build();
     Request.Builder request = new Request.Builder().url(requestUrl).get();
     return executeRequest(request, response -> readResponseJson(response, Pools.class));

--- a/src/main/java/io/gatling/plugin/client/http/PrivateApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/PrivateApiRequests.java
@@ -16,8 +16,8 @@
 
 package io.gatling.plugin.client.http;
 
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
-import io.gatling.plugin.client.exceptions.UnsupportedClientException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.exceptions.UnsupportedClientException;
 import java.net.HttpURLConnection;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -30,7 +30,7 @@ class PrivateApiRequests extends AbstractApiRequests {
   }
 
   /** @throws UnsupportedClientException if this client version is outdated */
-  void checkVersionSupport(String client, String version) throws EnterpriseClientException {
+  void checkVersionSupport(String client, String version) throws EnterprisePluginException {
     Request.Builder request = checkVersionSupportRequest(client, version);
     executeRequest(
         request,

--- a/src/main/java/io/gatling/plugin/client/http/SimulationsApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/SimulationsApiRequests.java
@@ -17,8 +17,8 @@
 package io.gatling.plugin.client.http;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
-import io.gatling.plugin.client.exceptions.SimulationNotFoundException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.exceptions.SimulationNotFoundException;
 import io.gatling.plugin.model.RunSummary;
 import io.gatling.plugin.model.Simulation;
 import io.gatling.plugin.model.SimulationCreationPayload;
@@ -37,7 +37,7 @@ class SimulationsApiRequests extends AbstractApiRequests {
     super(okHttpClient, url, token);
   }
 
-  Simulation getSimulation(UUID simulationId) throws EnterpriseClientException {
+  Simulation getSimulation(UUID simulationId) throws EnterprisePluginException {
     HttpUrl requestUrl =
         url.newBuilder()
             .addPathSegment("simulations")
@@ -54,7 +54,7 @@ class SimulationsApiRequests extends AbstractApiRequests {
         });
   }
 
-  Simulations listSimulations() throws EnterpriseClientException {
+  Simulations listSimulations() throws EnterprisePluginException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("simulations").build();
     Request.Builder request = new Request.Builder().url(requestUrl).get();
     return executeRequest(
@@ -67,7 +67,7 @@ class SimulationsApiRequests extends AbstractApiRequests {
   }
 
   Simulation createSimulation(SimulationCreationPayload simulation)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("simulations").build();
     RequestBody body = jsonRequestBody(simulation);
     Request.Builder request = new Request.Builder().url(requestUrl).post(body);
@@ -75,7 +75,7 @@ class SimulationsApiRequests extends AbstractApiRequests {
   }
 
   RunSummary startSimulation(UUID simulationId, List<SystemProperty> systemProperties)
-      throws EnterpriseClientException {
+      throws EnterprisePluginException {
     HttpUrl requestUrl =
         url.newBuilder()
             .addPathSegments("simulations/start")

--- a/src/main/java/io/gatling/plugin/client/http/TeamsApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/TeamsApiRequests.java
@@ -16,7 +16,7 @@
 
 package io.gatling.plugin.client.http;
 
-import io.gatling.plugin.client.exceptions.EnterpriseClientException;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.model.Teams;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -27,7 +27,7 @@ class TeamsApiRequests extends AbstractApiRequests {
     super(okHttpClient, url, token);
   }
 
-  Teams listTeams() throws EnterpriseClientException {
+  Teams listTeams() throws EnterprisePluginException {
     HttpUrl requestUrl = url.newBuilder().addPathSegment("teams").build();
     Request.Builder request = new Request.Builder().url(requestUrl).get();
     return executeRequest(request, response -> readResponseJson(response, Teams.class));

--- a/src/main/java/io/gatling/plugin/exceptions/ApiCallIOException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/ApiCallIOException.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-import java.util.UUID;
+import java.io.IOException;
 
-public final class SimulationNotFoundException extends EnterpriseClientException {
-  public SimulationNotFoundException(UUID simulationId) {
-    super("Simulation with id " + simulationId + " not found");
+public final class ApiCallIOException extends EnterprisePluginException {
+  public ApiCallIOException(IOException cause) {
+    super("Unable to call the Gatling Enterprise public API", cause);
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/EnterprisePluginException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/EnterprisePluginException.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public abstract class EnterpriseClientException extends Exception {
+public abstract class EnterprisePluginException extends Exception {
 
-  public EnterpriseClientException(String message) {
+  public EnterprisePluginException(String message) {
     super(message);
   }
 
-  public EnterpriseClientException(String message, Throwable cause) {
+  public EnterprisePluginException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/ForbiddenApiCallException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/ForbiddenApiCallException.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class InvalidApiCallException extends EnterpriseClientException {
-  public InvalidApiCallException(String details) {
-    super("Invalid request to the Gatling Enterprise API: " + details);
+public final class ForbiddenApiCallException extends EnterprisePluginException {
+  public ForbiddenApiCallException() {
+    super(
+        "API token valid but lacks required privileges: please configure a token with the role 'Configure' (see https://gatling.io/docs/enterprise/cloud/reference/admin/api_tokens/)");
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/InvalidApiCallException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/InvalidApiCallException.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class UnhandledApiCallException extends EnterpriseClientException {
-  public UnhandledApiCallException(int code, String body) {
-    super(String.format("Unhandled API response (status code: %s, body: %s)", code, body));
+public final class InvalidApiCallException extends EnterprisePluginException {
+  public InvalidApiCallException(String details) {
+    super("Invalid request to the Gatling Enterprise API: " + details);
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/JsonRequestProcessingException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/JsonRequestProcessingException.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-import java.io.IOException;
+public final class JsonRequestProcessingException extends RuntimeException {
 
-public final class ApiCallIOException extends EnterpriseClientException {
-  public ApiCallIOException(IOException cause) {
-    super("Unable to call the Gatling Enterprise public API", cause);
+  public JsonRequestProcessingException(Throwable cause) {
+    super("Unable to serialize JSON request to the Gatling Enterprise API", cause);
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/JsonResponseProcessingException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/JsonResponseProcessingException.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-import java.util.UUID;
+public final class JsonResponseProcessingException extends RuntimeException {
 
-public final class TeamNotFoundException extends EnterpriseClientException {
-  public TeamNotFoundException(UUID teamId) {
-    super("Team with id " + teamId + " not found");
+  public JsonResponseProcessingException(Throwable cause) {
+    super("Unable to parse JSON response from the Gatling Enterprise API", cause);
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/PackageNotFoundException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/PackageNotFoundException.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
 import java.util.UUID;
 
-public final class PackageNotFoundException extends EnterpriseClientException {
+public final class PackageNotFoundException extends EnterprisePluginException {
   public PackageNotFoundException(UUID packageId) {
     super("Package with id " + packageId + " not found");
   }

--- a/src/main/java/io/gatling/plugin/exceptions/SeveralTeamsFoundException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/SeveralTeamsFoundException.java
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class UnsupportedClientException extends EnterpriseClientException {
-  public UnsupportedClientException(String client, String version) {
-    super(
-        "Client "
-            + client
-            + " version "
-            + version
-            + " is no longer supported; please upgrade to the latest version");
+import io.gatling.plugin.model.Team;
+import java.util.List;
+
+public final class SeveralTeamsFoundException extends EnterprisePluginException {
+
+  private final List<Team> availableTeams;
+
+  public SeveralTeamsFoundException(List<Team> availableTeams, String message) {
+    super(message);
+    this.availableTeams = availableTeams;
+  }
+
+  public List<Team> getAvailableTeams() {
+    return availableTeams;
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/SimulationNotFoundException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/SimulationNotFoundException.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class UnauthorizedApiCallException extends EnterpriseClientException {
-  public UnauthorizedApiCallException() {
-    super(
-        "API token not recognized: please configure a valid token (with the role 'All'; see https://gatling.io/docs/enterprise/cloud/reference/admin/api_tokens/)");
+import java.util.UUID;
+
+public final class SimulationNotFoundException extends EnterprisePluginException {
+  public SimulationNotFoundException(UUID simulationId) {
+    super("Simulation with id " + simulationId + " not found");
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/SimulationStartException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/SimulationStartException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.exceptions;
+
+import io.gatling.plugin.model.Simulation;
+
+public class SimulationStartException extends EnterprisePluginException {
+
+  private final Simulation simulation;
+
+  public SimulationStartException(Simulation simulation, Throwable cause) {
+    super("Failed to start simulation", cause);
+    this.simulation = simulation;
+  }
+
+  public Simulation getSimulation() {
+    return simulation;
+  }
+}

--- a/src/main/java/io/gatling/plugin/exceptions/TeamNotFoundException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/TeamNotFoundException.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class JsonRequestProcessingException extends RuntimeException {
+import java.util.UUID;
 
-  public JsonRequestProcessingException(Throwable cause) {
-    super("Unable to serialize JSON request to the Gatling Enterprise API", cause);
+public final class TeamNotFoundException extends EnterprisePluginException {
+  public TeamNotFoundException(UUID teamId) {
+    super("Team with id " + teamId + " not found");
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/UnauthorizedApiCallException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/UnauthorizedApiCallException.java
@@ -14,21 +14,11 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-import io.gatling.plugin.model.Team;
-import java.util.List;
-
-public final class SeveralTeamsFoundException extends EnterpriseClientException {
-
-  private final List<Team> availableTeams;
-
-  public SeveralTeamsFoundException(List<Team> availableTeams, String message) {
-    super(message);
-    this.availableTeams = availableTeams;
-  }
-
-  public List<Team> getAvailableTeams() {
-    return availableTeams;
+public final class UnauthorizedApiCallException extends EnterprisePluginException {
+  public UnauthorizedApiCallException() {
+    super(
+        "API token not recognized: please configure a valid token (with the role 'All'; see https://gatling.io/docs/enterprise/cloud/reference/admin/api_tokens/)");
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/UnhandledApiCallException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/UnhandledApiCallException.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class ForbiddenApiCallException extends EnterpriseClientException {
-  public ForbiddenApiCallException() {
-    super(
-        "API token valid but lacks required privileges: please configure a token with the role 'Configure' (see https://gatling.io/docs/enterprise/cloud/reference/admin/api_tokens/)");
+public final class UnhandledApiCallException extends EnterprisePluginException {
+  public UnhandledApiCallException(int code, String body) {
+    super(String.format("Unhandled API response (status code: %s, body: %s)", code, body));
   }
 }

--- a/src/main/java/io/gatling/plugin/exceptions/UnsupportedClientException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/UnsupportedClientException.java
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-package io.gatling.plugin.client.exceptions;
+package io.gatling.plugin.exceptions;
 
-public final class JsonResponseProcessingException extends RuntimeException {
-
-  public JsonResponseProcessingException(Throwable cause) {
-    super("Unable to parse JSON response from the Gatling Enterprise API", cause);
+public final class UnsupportedClientException extends EnterprisePluginException {
+  public UnsupportedClientException(String client, String version) {
+    super(
+        "Client "
+            + client
+            + " version "
+            + version
+            + " is no longer supported; please upgrade to the latest version");
   }
 }

--- a/src/main/java/io/gatling/plugin/io/JavaPluginScanner.java
+++ b/src/main/java/io/gatling/plugin/io/JavaPluginScanner.java
@@ -28,11 +28,11 @@ public class JavaPluginScanner implements PluginScanner {
 
   @Override
   public String readString() {
-    return scanner.nextLine();
+    return scanner.nextLine().trim();
   }
 
   @Override
   public int readInt() throws NumberFormatException {
-    return Integer.parseInt(readString());
+    return Integer.parseInt(readString().trim());
   }
 }

--- a/src/main/java/io/gatling/plugin/model/Packages.java
+++ b/src/main/java/io/gatling/plugin/model/Packages.java
@@ -24,10 +24,10 @@ import java.util.List;
 import java.util.Objects;
 
 public final class Packages {
-  public final List<PackageIndex> data;
+  public final List<PkgIndex> data;
 
   @JsonCreator
-  public Packages(@JsonProperty(value = "data", required = true) List<PackageIndex> data) {
+  public Packages(@JsonProperty(value = "data", required = true) List<PkgIndex> data) {
     nonNullParam(data, "data");
     this.data = data;
   }

--- a/src/main/java/io/gatling/plugin/model/PkgIndex.java
+++ b/src/main/java/io/gatling/plugin/model/PkgIndex.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.UUID;
 
-public final class PackageIndex {
+public final class PkgIndex {
   public final UUID id;
   /** Optional. */
   public final UUID teamId;
@@ -33,7 +33,7 @@ public final class PackageIndex {
   public final String fileName;
 
   @JsonCreator
-  public PackageIndex(
+  public PkgIndex(
       @JsonProperty(value = "id", required = true) UUID id,
       @JsonProperty(value = "teamId") UUID teamId,
       @JsonProperty(value = "name", required = true) String name,
@@ -50,7 +50,7 @@ public final class PackageIndex {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    PackageIndex aPackage = (PackageIndex) o;
+    PkgIndex aPackage = (PkgIndex) o;
     return id.equals(aPackage.id)
         && Objects.equals(teamId, aPackage.teamId)
         && name.equals(aPackage.name)

--- a/src/main/java/io/gatling/plugin/model/SimulationStartResult.java
+++ b/src/main/java/io/gatling/plugin/model/SimulationStartResult.java
@@ -20,35 +20,40 @@ import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import java.util.Objects;
 
-public class SimulationAndRunSummary {
+public class SimulationStartResult {
 
   public final Simulation simulation;
   public final RunSummary runSummary;
+  public final boolean createdSimulation;
 
-  public SimulationAndRunSummary(Simulation simulation, RunSummary runSummary) {
+  public SimulationStartResult(
+      Simulation simulation, RunSummary runSummary, boolean createdSimulation) {
     nonNullParam(simulation, "simulation");
     nonNullParam(runSummary, "runSummary");
     this.simulation = simulation;
     this.runSummary = runSummary;
+    this.createdSimulation = createdSimulation;
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    SimulationAndRunSummary that = (SimulationAndRunSummary) o;
+    SimulationStartResult that = (SimulationStartResult) o;
     return Objects.equals(simulation, that.simulation)
-        && Objects.equals(runSummary, that.runSummary);
+        && Objects.equals(runSummary, that.runSummary)
+        && Objects.equals(createdSimulation, that.createdSimulation);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(simulation, runSummary);
+    return Objects.hash(simulation, runSummary, createdSimulation);
   }
 
   @Override
   public String toString() {
     return String.format(
-        "SimulationAndRunSummary{simulation=%s, runSummary=%s}", simulation, runSummary);
+        "SimulationAndRunSummary{simulation=%s, runSummary=%s, createdSimulation=%s}",
+        simulation, runSummary, createdSimulation);
   }
 }

--- a/src/test/java/io/gatling/plugin/model/JsonUnmarshallingTest.java
+++ b/src/test/java/io/gatling/plugin/model/JsonUnmarshallingTest.java
@@ -36,17 +36,17 @@ public class JsonUnmarshallingTest {
     final Packages expected =
         new Packages(
             Arrays.asList(
-                new PackageIndex(
+                new PkgIndex(
                     UUID.fromString("c0074b5a-5b97-4fbb-bad9-b3848bac3082"),
                     null,
                     "First package",
                     null),
-                new PackageIndex(
+                new PkgIndex(
                     UUID.fromString("44191a0c-2e15-49b3-8876-7aa47cc97587"),
                     UUID.fromString("40084389-c812-42c1-aaef-f8730959510c"),
                     "Second package",
                     null),
-                new PackageIndex(
+                new PkgIndex(
                     UUID.fromString("0cf26226-b261-4af6-a52a-1fec36f4394a"),
                     UUID.fromString("c5f9e46c-3860-4d95-a851-db0814bdd360"),
                     "Third package",

--- a/src/test/java/io/gatling/plugin/util/OkHttpEnterpriseClientTest.java
+++ b/src/test/java/io/gatling/plugin/util/OkHttpEnterpriseClientTest.java
@@ -18,8 +18,8 @@ package io.gatling.plugin.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.gatling.plugin.client.exceptions.*;
 import io.gatling.plugin.client.http.OkHttpEnterpriseClient;
+import io.gatling.plugin.exceptions.*;
 import io.gatling.plugin.io.PluginLogger;
 import java.io.File;
 import java.net.HttpURLConnection;
@@ -64,7 +64,7 @@ public class OkHttpEnterpriseClientTest {
               noOpLogger, OK_HTTP_CLIENT, server.url("/").url(), TOKEN, "client", "version");
       server.takeRequest(); // Remove checkVersion enqueue request
       return client;
-    } catch (EnterpriseClientException | InterruptedException e) {
+    } catch (EnterprisePluginException | InterruptedException e) {
       throw new IllegalStateException(
           "Test version support should always work from enqueue response", e);
     }
@@ -72,7 +72,7 @@ public class OkHttpEnterpriseClientTest {
 
   @Test
   void UploadPackage_ContentType_OctetStream()
-      throws EnterpriseClientException, InterruptedException {
+      throws EnterprisePluginException, InterruptedException {
     MockWebServer server =
         mockWebServer(new MockResponse().setResponseCode(HttpURLConnection.HTTP_OK));
     OkHttpEnterpriseClient client = okHttpEnterpriseClientMockWebServer(server);
@@ -82,7 +82,7 @@ public class OkHttpEnterpriseClientTest {
 
   @Test
   void UploadPackage_ContentLength_MavenSampleLength()
-      throws EnterpriseClientException, InterruptedException {
+      throws EnterprisePluginException, InterruptedException {
     MockWebServer server =
         mockWebServer(new MockResponse().setResponseCode(HttpURLConnection.HTTP_OK));
     OkHttpEnterpriseClient client = okHttpEnterpriseClientMockWebServer(server);
@@ -91,23 +91,23 @@ public class OkHttpEnterpriseClientTest {
         ARTIFACT_FILE.length(), Long.valueOf(server.takeRequest().getHeader("Content-Length")));
   }
 
-  private EnterpriseClientException UploadPackage_Status_EnterpriseClientException(int code) {
+  private EnterprisePluginException UploadPackage_Status_EnterpriseClientException(int code) {
     MockWebServer server = mockWebServer(new MockResponse().setResponseCode(code));
     OkHttpEnterpriseClient client = okHttpEnterpriseClientMockWebServer(server);
     return assertThrows(
-        EnterpriseClientException.class, () -> client.uploadPackage(ARTIFACT_ID, ARTIFACT_FILE));
+        EnterprisePluginException.class, () -> client.uploadPackage(ARTIFACT_ID, ARTIFACT_FILE));
   }
 
   @Test
   void UploadPackage_StatusNotFound_EnterpriseClientException() {
-    EnterpriseClientException e =
+    EnterprisePluginException e =
         UploadPackage_Status_EnterpriseClientException(HttpURLConnection.HTTP_NOT_FOUND);
     assertTrue(e instanceof PackageNotFoundException);
   }
 
   @Test
   void UploadPackage_StatusEntityTooLarge_EnterpriseClientException() {
-    EnterpriseClientException e =
+    EnterprisePluginException e =
         UploadPackage_Status_EnterpriseClientException(HttpURLConnection.HTTP_ENTITY_TOO_LARGE);
     assertTrue(e instanceof InvalidApiCallException);
     assertTrue(e.getMessage().contains("Package exceeds maximum allowed size (5 GB)"));
@@ -115,14 +115,14 @@ public class OkHttpEnterpriseClientTest {
 
   @Test
   void UploadPackage_StatusUnauthorized_EnterpriseClientException() {
-    EnterpriseClientException e =
+    EnterprisePluginException e =
         UploadPackage_Status_EnterpriseClientException(HttpURLConnection.HTTP_UNAUTHORIZED);
     assertTrue(e instanceof UnauthorizedApiCallException);
   }
 
   @Test
   void UploadPackage_StatusUnknown_EnterpriseClientException() {
-    EnterpriseClientException e = UploadPackage_Status_EnterpriseClientException(666);
+    EnterprisePluginException e = UploadPackage_Status_EnterpriseClientException(666);
     assertTrue(e instanceof UnhandledApiCallException);
     assertTrue(e.getMessage().contains("666"));
   }


### PR DESCRIPTION
Motivation:

UX improvements after demo & tests with the Maven plugin.

Modifications:

- Generally don't automatically pick a choice in a list of only 1 element (to ask for confirmation)
- Always try to use an explicitly configured value (may lead to an error if the value is incorrect, but doesn't ignore an explicit user setting)
- Use alphabetical sort in lists
- Remove injectors size upper bound
- Add the information of whether or not a new simulation was created to the result when starting a simulation
- Some wording improvements