### PR TITLE
fix: checksum on interactive start

### DIFF
--- a/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
@@ -21,6 +21,7 @@ import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import io.gatling.plugin.client.EnterpriseClient;
 import io.gatling.plugin.exceptions.*;
+import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.model.*;
 import io.gatling.plugin.model.Pkg;
 import java.io.File;
@@ -28,15 +29,15 @@ import java.util.*;
 
 public final class EnterprisePluginClient extends PluginClient implements EnterprisePlugin {
 
-  public EnterprisePluginClient(EnterpriseClient enterpriseClient) {
-    super(enterpriseClient);
+  public EnterprisePluginClient(EnterpriseClient enterpriseClient, PluginLogger logger) {
+    super(enterpriseClient, logger);
   }
 
   @Override
   public long uploadPackage(UUID packageId, File file) throws EnterprisePluginException {
     nonNullParam(packageId, "packageId");
     nonNullParam(file, "file");
-    return enterpriseClient.uploadPackageWithChecksum(packageId, file);
+    return uploadPackageWithChecksum(packageId, file);
   }
 
   @Override

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
@@ -86,8 +86,11 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
 
   private void uploadPackage(UUID artifactId, File packageFile) throws EnterprisePluginException {
     logger.info("Uploading package...");
-    enterpriseClient.uploadPackage(artifactId, packageFile);
-    logger.info("Package uploaded");
+    if (enterpriseClient.uploadPackageWithChecksum(artifactId, packageFile) == -1) {
+      logger.info("No code changes detected, skipping package upload");
+    } else {
+      logger.info("Package uploaded");
+    }
   }
 
   private SimulationStartResult startSimulation(

--- a/src/main/java/io/gatling/plugin/PluginClient.java
+++ b/src/main/java/io/gatling/plugin/PluginClient.java
@@ -16,13 +16,33 @@
 
 package io.gatling.plugin;
 
+import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
+
 import io.gatling.plugin.client.EnterpriseClient;
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.io.PluginLogger;
+import java.io.File;
+import java.util.UUID;
 
 abstract class PluginClient {
 
   protected final EnterpriseClient enterpriseClient;
+  protected final PluginLogger logger;
 
-  public PluginClient(EnterpriseClient enterpriseClient) {
+  public PluginClient(EnterpriseClient enterpriseClient, PluginLogger logger) {
     this.enterpriseClient = enterpriseClient;
+    this.logger = logger;
+  }
+
+  protected long uploadPackageWithChecksum(UUID packageId, File file)
+      throws EnterprisePluginException {
+    nonNullParam(packageId, "packageId");
+    nonNullParam(file, "file");
+    if (enterpriseClient.uploadPackageWithChecksum(packageId, file) == -1) {
+      logger.info("No code changes detected, skipping package upload");
+    } else {
+      logger.info("Package uploaded");
+    }
+    return file.length();
   }
 }

--- a/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
@@ -63,6 +63,11 @@ public interface EnterpriseClient {
   RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties)
       throws EnterprisePluginException;
 
+  /**
+   * @param packageId Required
+   * @param file Required
+   * @return file size if uploaded, -1 when checksum are equals
+   */
   long uploadPackageWithChecksum(UUID packageId, File file) throws EnterprisePluginException;
 
   Simulation createSimulation(

--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -16,13 +16,10 @@
 
 package io.gatling.plugin.client.http;
 
-import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
-
 import io.gatling.plugin.client.EnterpriseClient;
 import io.gatling.plugin.exceptions.ApiCallIOException;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.exceptions.PackageNotFoundException;
-import io.gatling.plugin.io.PluginLogger;
 import io.gatling.plugin.model.*;
 import io.gatling.plugin.util.checksum.PkgChecksum;
 import java.io.File;
@@ -37,7 +34,6 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   private static final Map<String, String> DEFAULT_SYSTEM_PROPERTIES = Collections.emptyMap();
   private static final MeaningfulTimeWindow DEFAULT_TIME_WINDOW = new MeaningfulTimeWindow(0, 0);
 
-  private final PluginLogger logger;
   private final PrivateApiRequests privateApiRequests;
   private final PackagesApiRequests packagesApiRequests;
   private final PoolsApiRequests poolsApiRequests;
@@ -45,35 +41,25 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   private final TeamsApiRequests teamsApiRequests;
 
   public static OkHttpEnterpriseClient getInstance(
-      PluginLogger logger,
-      OkHttpClient okHttpClient,
-      URL url,
-      String token,
-      String client,
-      String version)
+      OkHttpClient okHttpClient, URL url, String token, String client, String version)
       throws EnterprisePluginException {
-    OkHttpEnterpriseClient enterpriseClient =
-        new OkHttpEnterpriseClient(logger, okHttpClient, url, token);
+    OkHttpEnterpriseClient enterpriseClient = new OkHttpEnterpriseClient(okHttpClient, url, token);
     enterpriseClient.privateApiRequests.checkVersionSupport(client, version);
     return enterpriseClient;
   }
 
   public static OkHttpEnterpriseClient getInstance(
-      PluginLogger logger, URL url, String token, String client, String version)
-      throws EnterprisePluginException {
-    return getInstance(logger, new OkHttpClient(), url, token, client, version);
+      URL url, String token, String client, String version) throws EnterprisePluginException {
+    return getInstance(new OkHttpClient(), url, token, client, version);
   }
 
-  private OkHttpEnterpriseClient(
-      PluginLogger logger, OkHttpClient okHttpClient, URL url, String token) {
-    nonNullParam(logger, "logger");
+  private OkHttpEnterpriseClient(OkHttpClient okHttpClient, URL url, String token) {
     final HttpUrl httpUrl = HttpUrl.get(url);
     if (httpUrl == null) {
       throw new IllegalArgumentException(
           String.format("'%s' is not a valid HTTP or HTTPS URL", url));
     }
 
-    this.logger = logger;
     this.privateApiRequests = new PrivateApiRequests(okHttpClient, httpUrl, token);
     this.packagesApiRequests = new PackagesApiRequests(okHttpClient, httpUrl, token);
     this.poolsApiRequests = new PoolsApiRequests(okHttpClient, httpUrl, token);
@@ -142,12 +128,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   @Override
   public long uploadPackageWithChecksum(UUID packageId, File file)
       throws EnterprisePluginException {
-    if (checksumComparison(packageId, file)) {
-      logger.info("No code changes detected, skipping package upload");
-      return file.length();
-    } else {
-      return uploadPackage(packageId, file);
-    }
+    return checksumComparison(packageId, file) ? -1 : uploadPackage(packageId, file);
   }
 
   @Override

--- a/src/test/java/io/gatling/plugin/util/OkHttpEnterpriseClientTest.java
+++ b/src/test/java/io/gatling/plugin/util/OkHttpEnterpriseClientTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import io.gatling.plugin.client.http.OkHttpEnterpriseClient;
 import io.gatling.plugin.exceptions.*;
-import io.gatling.plugin.io.PluginLogger;
 import java.io.File;
 import java.net.HttpURLConnection;
 import java.util.Arrays;
@@ -51,17 +50,9 @@ public class OkHttpEnterpriseClientTest {
 
   private OkHttpEnterpriseClient okHttpEnterpriseClientMockWebServer(MockWebServer server) {
     try {
-      PluginLogger noOpLogger =
-          new PluginLogger() {
-            @Override
-            public void info(String message) {}
-
-            @Override
-            public void error(String message) {}
-          };
       OkHttpEnterpriseClient client =
           OkHttpEnterpriseClient.getInstance(
-              noOpLogger, OK_HTTP_CLIENT, server.url("/").url(), TOKEN, "client", "version");
+              OK_HTTP_CLIENT, server.url("/").url(), TOKEN, "client", "version");
       server.takeRequest(); // Remove checkVersion enqueue request
       return client;
     } catch (EnterprisePluginException | InterruptedException e) {


### PR DESCRIPTION
**Motivation:**
No checksum control when uploading to an existing package on interactive mode

**Modification:**
* Remove logger from OkHttpEnterpriseClient
* Return -1 when file upload have been skipped on checksum control
* Base on returned value, log package uploaded or upload skipped