### PR TITLE
fix: log upload skip due to checksum control

### DIFF
--- a/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePluginClient.java
@@ -58,7 +58,7 @@ public final class EnterprisePluginClient extends PluginClient implements Enterp
     nonNullParam(file, "file");
 
     final Simulation simulation = enterpriseClient.getSimulation(simulationId);
-    enterpriseClient.uploadPackageWithChecksum(simulation.pkgId, file);
+    uploadPackageWithChecksum(simulation.pkgId, file);
     final RunSummary runSummary = enterpriseClient.startSimulation(simulationId, systemProperties);
     return new SimulationStartResult(simulation, runSummary, false);
   }


### PR DESCRIPTION
**Modification:**
Make use of  herited `uploadPackageWithChecksum` instead of direct client call.

**Ref:** MISC-330