### PR TITLE
Extracted Fork mechanism from gatling-maven-plugin to plugin-commons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import net.moznion.sbt.spotless.config.{GoogleJavaFormatConfig, JavaConfig, SpotlessConfig}
+import net.moznion.sbt.spotless.config.{ GoogleJavaFormatConfig, JavaConfig, SpotlessConfig }
 
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 
@@ -26,7 +26,9 @@ lazy val root = (project in file("."))
       "net.aichler"                % "jupiter-interface"    % JupiterKeys.jupiterVersion.value % Test,
       "com.squareup.okhttp3"       % "mockwebserver"        % okHttp3Version                   % Test,
       "com.squareup.okhttp3"       % "okhttp"               % okHttp3Version,
-      "com.fasterxml.jackson.core" % "jackson-databind"     % "2.13.1"
+      "com.fasterxml.jackson.core" % "jackson-databind"     % "2.13.1",
+      "org.apache.commons"         % "commons-exec"         % "1.3",
+      "org.codehaus.plexus"        % "plexus-utils"         % "3.4.1"
     ),
     spotlessJava := JavaConfig(
       googleJavaFormat = GoogleJavaFormatConfig()

--- a/src/main/java/io/gatling/plugin/exceptions/UserQuitException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/UserQuitException.java
@@ -18,6 +18,6 @@ package io.gatling.plugin.exceptions;
 
 public class UserQuitException extends EnterprisePluginException {
   public UserQuitException() {
-    super("Execution quit by user");
+    super("Execution cancelled by user");
   }
 }

--- a/src/main/java/io/gatling/plugin/util/Fork.java
+++ b/src/main/java/io/gatling/plugin/util/Fork.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import io.gatling.plugin.io.PluginLogger;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.apache.commons.exec.*;
+import org.codehaus.plexus.util.StringUtils;
+
+public class Fork {
+
+  private static final String ARG_FILE_PREFIX = "gatling-";
+  private static final String ARG_FILE_SUFFIX = ".args";
+  private static final String GATLING_MANIFEST_VALUE = "GATLING_ZINC";
+
+  private final String javaExecutable;
+  private final String mainClassName;
+  private final List<String> classpath;
+  private final boolean propagateSystemProperties;
+  private final PluginLogger log;
+  private final File workingDirectory;
+
+  private final List<String> jvmArgs = new ArrayList<>();
+  private final List<String> args = new ArrayList<>();
+
+  public Fork(
+      String mainClassName, //
+      List<String> classpath, //
+      List<String> jvmArgs, //
+      List<String> args, //
+      String javaExecutable, //
+      boolean propagateSystemProperties, //
+      PluginLogger log) {
+
+    this(
+        mainClassName,
+        classpath,
+        jvmArgs,
+        args,
+        javaExecutable,
+        propagateSystemProperties,
+        log,
+        null);
+  }
+
+  public Fork(
+      String mainClassName, //
+      List<String> classpath, //
+      List<String> jvmArgs, //
+      List<String> args, //
+      String javaExecutable, //
+      boolean propagateSystemProperties, //
+      PluginLogger log, //
+      File workingDirectory) {
+
+    this.mainClassName = mainClassName;
+    this.classpath = classpath;
+    this.jvmArgs.addAll(jvmArgs);
+    this.args.addAll(args);
+    this.javaExecutable = javaExecutable;
+    this.propagateSystemProperties = propagateSystemProperties;
+    this.log = log;
+    this.workingDirectory = workingDirectory;
+  }
+
+  public static boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("win");
+
+  private String toWindowsShortName(String value) {
+    if (IS_WINDOWS) {
+      int programFilesIndex = value.indexOf("Program Files");
+      if (programFilesIndex >= 0) {
+        // Could be "Program Files" or "Program Files (x86)"
+        int firstSeparatorAfterProgramFiles =
+            value.indexOf(File.separator, programFilesIndex + "Program Files".length());
+        File longNameDir =
+            firstSeparatorAfterProgramFiles < 0
+                ? new File(value)
+                : // C:\\Program Files with
+                // trailing separator
+                new File(value.substring(0, firstSeparatorAfterProgramFiles)); // chop child
+        // Some other sibling dir could be PrograXXX and might shift short name index
+        // so we can't be sure "Program Files" is "Progra~1" and "Program Files (x86)"
+        // is "Progra~2"
+        for (int i = 0; i < 10; i++) {
+          File shortNameDir = new File(longNameDir.getParent(), "Progra~" + i);
+          if (shortNameDir.equals(longNameDir)) {
+            return shortNameDir.toString();
+          }
+        }
+      }
+    }
+
+    return value;
+  }
+
+  private String safe(String value) {
+    return value.contains(" ") ? '"' + value + '"' : value;
+  }
+
+  public void run() throws Exception {
+    if (propagateSystemProperties) {
+      for (Entry<Object, Object> systemProp : System.getProperties().entrySet()) {
+        String name = systemProp.getKey().toString();
+        String value = toWindowsShortName(systemProp.getValue().toString());
+        if (isPropagatableProperty(name)) {
+          if (name.contains(" ")) {
+            log.error(
+                "System property name '"
+                    + name
+                    + "' contains a whitespace and can't be propagated");
+
+          } else if (IS_WINDOWS && value.contains(" ")) {
+            log.error(
+                "System property value '"
+                    + value
+                    + "' contains a whitespace and can't be propagated on Windows");
+
+          } else {
+            this.jvmArgs.add("-D" + name + "=" + safe(StringUtils.escape(value)));
+          }
+        }
+      }
+    }
+
+    this.jvmArgs.add("-jar");
+
+    this.jvmArgs.add(
+        createBooterJar(classpath, MainWithArgsInFile.class.getName()).getCanonicalPath());
+
+    List<String> command = buildCommand();
+
+    Executor exec = new DefaultExecutor();
+    exec.setStreamHandler(new PumpStreamHandler(System.out, System.err, System.in));
+    exec.setProcessDestroyer(new ShutdownHookProcessDestroyer());
+    if (workingDirectory != null) {
+      exec.setWorkingDirectory(workingDirectory);
+    }
+
+    CommandLine cl = new CommandLine(javaExecutable);
+    for (String arg : command) {
+      cl.addArgument(arg, false);
+    }
+
+    int exitValue = exec.execute(cl);
+    if (exitValue != 0) {
+      throw new IllegalStateException("command line returned non-zero value:" + exitValue);
+    }
+  }
+
+  private List<String> buildCommand() throws IOException {
+    ArrayList<String> command = new ArrayList<>(jvmArgs.size() + 2);
+    command.addAll(jvmArgs);
+    command.add(mainClassName);
+    command.add(createArgFile(args).getCanonicalPath());
+    return command;
+  }
+
+  /**
+   * Create a jar with just a manifest containing a Main-Class entry for BooterConfiguration and a
+   * Class-Path entry for all classpath elements.
+   *
+   * @param classPath List of all classpath elements.
+   * @param startClassName The classname to start (main-class)
+   * @return The file pointing to the jar
+   * @throws java.io.IOException When a file operation fails.
+   */
+  private static File createBooterJar(List<String> classPath, String startClassName)
+      throws IOException {
+    File file = File.createTempFile("gatlingbooter", ".jar");
+    file.deleteOnExit();
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(file))) {
+      jos.setLevel(JarOutputStream.STORED);
+      JarEntry je = new JarEntry("META-INF/MANIFEST.MF");
+      jos.putNextEntry(je);
+
+      Manifest manifest = new Manifest();
+
+      // we can't use StringUtils.join here since we need to add a '/' to
+      // the end of directory entries - otherwise the jvm will ignore them.
+      StringBuilder cp = new StringBuilder();
+      for (String el : classPath) {
+        // NOTE: if File points to a directory, this entry MUST end in '/'.
+        cp.append(getURL(new File(el)).toExternalForm()).append(" ");
+      }
+      cp.setLength(cp.length() - 1);
+
+      manifest.getMainAttributes().putValue(Attributes.Name.MANIFEST_VERSION.toString(), "1.0");
+      manifest.getMainAttributes().putValue(Attributes.Name.CLASS_PATH.toString(), cp.toString());
+      manifest.getMainAttributes().putValue(Attributes.Name.MAIN_CLASS.toString(), startClassName);
+      manifest.getMainAttributes().putValue(GATLING_MANIFEST_VALUE, "true");
+
+      manifest.write(jos);
+    }
+
+    return file;
+  }
+
+  private static URL getURL(File file) throws MalformedURLException {
+
+    // encode any characters that do not comply with RFC 2396
+    // this is primarily to handle Windows where the user's home directory contains
+    // spaces
+
+    return new URL(file.toURI().toASCIIString());
+  }
+
+  private boolean isPropagatableProperty(String name) {
+    return !name.startsWith("java.") //
+        && !name.startsWith("sun.") //
+        && !name.startsWith("maven.") //
+        && !name.startsWith("file.") //
+        && !name.startsWith("awt.") //
+        && !name.startsWith("os.") //
+        && !name.startsWith("user.") //
+        && !name.startsWith("idea.") //
+        && !name.startsWith("guice.") //
+        && !name.startsWith("hudson.") //
+        && !name.equals("line.separator") //
+        && !name.equals("path.separator") //
+        && !name.equals("classworlds.conf") //
+        && !name.equals("org.slf4j.simpleLogger.defaultLogLevel");
+  }
+
+  private File createArgFile(List<String> args) throws IOException {
+    final File argFile = File.createTempFile(ARG_FILE_PREFIX, ARG_FILE_SUFFIX);
+    argFile.deleteOnExit();
+    try (PrintWriter out = new PrintWriter(argFile)) {
+      for (String arg : args) {
+        out.println(arg);
+      }
+      return argFile;
+    }
+  }
+}

--- a/src/main/java/io/gatling/plugin/util/MainWithArgsInFile.java
+++ b/src/main/java/io/gatling/plugin/util/MainWithArgsInFile.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MainWithArgsInFile {
+
+  public static void main(String[] args) {
+    try {
+      String mainClassName = args[0];
+      List<String> argsFromFile = readArgFile(new File(args[1]));
+      runMain(mainClassName, argsFromFile);
+    } catch (Throwable t) {
+      t.printStackTrace();
+      System.exit(-1);
+    }
+  }
+
+  private static void runMain(String mainClassName, List<String> args) throws Exception {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    Class<?> mainClass = cl.loadClass(mainClassName);
+    Method mainMethod = mainClass.getMethod("main", String[].class);
+    int mods = mainMethod.getModifiers();
+    if (mainMethod.getReturnType() != void.class
+        || !Modifier.isStatic(mods)
+        || !Modifier.isPublic(mods)) {
+      throw new NoSuchMethodException("main");
+    }
+
+    String[] argsArray = args.toArray(new String[0]);
+    mainMethod.invoke(null, new Object[] {argsArray});
+  }
+
+  private static List<String> readArgFile(File argFile) throws IOException {
+    ArrayList<String> args = new ArrayList<>();
+    try (final FileReader fr = new FileReader(argFile);
+        final BufferedReader in = new BufferedReader(fr)) {
+      String line;
+      while ((line = in.readLine()) != null) {
+        args.add(line);
+      }
+      return args;
+    }
+  }
+}


### PR DESCRIPTION
Motivation:
- The fork mechanism will be used by both the bundle and the maven plugin, it needs to be in a common project

Modification:
- copied the Fork and MainWithArgsInFile classes
- modified the way used by ZincCompiler to check if the jar is a Gatling one: added a custom manifest attribute
- PluginLogger is now used to log errors
- requires the path to the java executable instead of the Toolchain

Result:
- bundle and maven plugin can now use the common Fork

ref: MISC-333