### PR TITLE
feat: reject bytecode with a version higher than max in server informations, closes MISC-371

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val root = (project in file("."))
       "com.squareup.okhttp3"       % "okhttp"               % okHttp3Version,
       "com.fasterxml.jackson.core" % "jackson-databind"     % "2.13.2.2",
       "org.apache.commons"         % "commons-exec"         % "1.3",
-      "io.gatling"                 % "gatling-scanner"      % "1.0.1"
+      "io.gatling"                 % "gatling-scanner"      % "1.1.0"
     ),
     spotlessJava := JavaConfig(
       googleJavaFormat = GoogleJavaFormatConfig()

--- a/src/main/java/io/gatling/plugin/EnterpriseSimulationScanner.java
+++ b/src/main/java/io/gatling/plugin/EnterpriseSimulationScanner.java
@@ -19,21 +19,21 @@ package io.gatling.plugin;
 import io.gatling.plugin.exceptions.EnterprisePluginException;
 import io.gatling.plugin.exceptions.SimulationScannerIOException;
 import io.gatling.scanner.AsmSimulationScanner;
+import io.gatling.scanner.SimulationScanResult;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 class EnterpriseSimulationScanner {
 
   /**
    * @param file JAR file to collect simulation fully qualified names
-   * @return simulation classes detected in file
+   * @return simulation classes detected in file, along with class with the highest bytecode version
    * @throws SimulationScannerIOException when IOException occurred in AsmSimulationScanner
    */
-  public static List<String> simulationFullyQualifiedNamesFromFile(File file)
+  public static SimulationScanResult simulationFullyQualifiedNamesFromFile(File file)
       throws EnterprisePluginException {
     try {
-      return AsmSimulationScanner.simulationFullyQualifiedNamesFromFile(file);
+      return AsmSimulationScanner.scan(file);
     } catch (IOException e) {
       throw new SimulationScannerIOException(file, e);
     }

--- a/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
+++ b/src/main/java/io/gatling/plugin/InteractiveEnterprisePluginClient.java
@@ -16,7 +16,6 @@
 
 package io.gatling.plugin;
 
-import static io.gatling.plugin.EnterpriseSimulationScanner.simulationFullyQualifiedNamesFromFile;
 import static io.gatling.plugin.util.ObjectsUtil.nonNullParam;
 
 import io.gatling.plugin.client.EnterpriseClient;
@@ -53,11 +52,11 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
     nonNullParam(file, "file");
 
     final Simulation simulation = enterpriseClient.getSimulation(simulationId);
-    final List<String> simulationClasses = simulationFullyQualifiedNamesFromFile(file);
+    List<String> discoveredSimulationClasses = simulationClassesFromCompatibleByteCodeFile(file);
 
     uploadPackageWithChecksum(simulation.pkgId, file);
     return launchSimulation(
-        simulation, systemProperties, configuredSimulationClass, simulationClasses);
+        simulation, systemProperties, configuredSimulationClass, discoveredSimulationClasses);
   }
 
   public SimulationStartResult createAndStartSimulation(
@@ -72,8 +71,7 @@ public final class InteractiveEnterprisePluginClient extends PluginClient
     nonNullParam(systemProperties, "systemProperties");
     nonNullParam(file, "file");
 
-    List<String> discoveredSimulationClasses =
-        EnterpriseSimulationScanner.simulationFullyQualifiedNamesFromFile(file);
+    List<String> discoveredSimulationClasses = simulationClassesFromCompatibleByteCodeFile(file);
 
     List<Simulation> simulations = enterpriseClient.getSimulations();
     boolean createSimulation = simulations.isEmpty() || chooseIfCreateSimulation();

--- a/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
@@ -36,6 +36,8 @@ import java.util.UUID;
  */
 public interface EnterpriseClient extends AutoCloseable {
 
+  ServerInformation getServerInformation() throws EnterprisePluginException;
+
   List<Simulation> getSimulations() throws EnterprisePluginException;
 
   Simulation getSimulation(UUID simulationId) throws EnterprisePluginException;

--- a/src/main/java/io/gatling/plugin/client/http/InfoApiRequests.java
+++ b/src/main/java/io/gatling/plugin/client/http/InfoApiRequests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.client.http;
+
+import io.gatling.plugin.exceptions.EnterprisePluginException;
+import io.gatling.plugin.model.ServerInformation;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+public class InfoApiRequests extends AbstractApiRequests {
+
+  InfoApiRequests(OkHttpClient okHttpClient, HttpUrl url, String token) {
+    super(okHttpClient, url, token);
+  }
+
+  ServerInformation getServerInformation() throws EnterprisePluginException {
+    HttpUrl requestUrl = url.newBuilder().addPathSegment("info").build();
+    Request.Builder request = new Request.Builder().url(requestUrl).get();
+    return executeRequest(request, response -> readResponseJson(response, ServerInformation.class));
+  }
+}

--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -34,6 +34,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   private static final MeaningfulTimeWindow DEFAULT_TIME_WINDOW = new MeaningfulTimeWindow(0, 0);
 
   private final OkHttpClient okHttpClient;
+  private final InfoApiRequests infoApiRequests;
   private final PrivateApiRequests privateApiRequests;
   private final PackagesApiRequests packagesApiRequests;
   private final PoolsApiRequests poolsApiRequests;
@@ -49,6 +50,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
     }
 
     okHttpClient = new OkHttpClient();
+    infoApiRequests = new InfoApiRequests(okHttpClient, httpUrl, token);
     privateApiRequests = new PrivateApiRequests(okHttpClient, httpUrl, token);
     packagesApiRequests = new PackagesApiRequests(okHttpClient, httpUrl, token);
     poolsApiRequests = new PoolsApiRequests(okHttpClient, httpUrl, token);
@@ -60,6 +62,11 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
       close();
       throw e;
     }
+  }
+
+  @Override
+  public ServerInformation getServerInformation() throws EnterprisePluginException {
+    return infoApiRequests.getServerInformation();
   }
 
   @Override

--- a/src/main/java/io/gatling/plugin/exceptions/UnsupportedJavaVersionException.java
+++ b/src/main/java/io/gatling/plugin/exceptions/UnsupportedJavaVersionException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.exceptions;
+
+public class UnsupportedJavaVersionException extends EnterprisePluginException {
+  public final String clazz;
+  public final int version;
+  public final int supportedVersion;
+
+  public UnsupportedJavaVersionException(String clazz, int version, int max) {
+    super(
+        String.format(
+            "Version of java %d (found for class '%s') is not supported. Maximum supported java version is %d.",
+            version, clazz, max));
+    this.clazz = clazz;
+    this.version = version;
+    this.supportedVersion = max;
+  }
+}

--- a/src/main/java/io/gatling/plugin/model/ServerInformation.java
+++ b/src/main/java/io/gatling/plugin/model/ServerInformation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class ServerInformation {
+
+  public final Versions versions;
+
+  @JsonCreator
+  public ServerInformation(@JsonProperty(value = "versions", required = true) Versions versions) {
+    this.versions = versions;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ServerInformation that = (ServerInformation) o;
+    return Objects.equals(versions, that.versions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(versions);
+  }
+
+  @Override
+  public String toString() {
+    return "ServerInformation{" + "versions=" + versions + '}';
+  }
+}

--- a/src/main/java/io/gatling/plugin/model/VersionSupported.java
+++ b/src/main/java/io/gatling/plugin/model/VersionSupported.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class VersionSupported {
+
+  public final String min;
+  public final String max;
+
+  @JsonCreator
+  public VersionSupported(
+      @JsonProperty(value = "min") String min, @JsonProperty(value = "max") String max) {
+    this.min = min;
+    this.max = max;
+  }
+
+  @Override
+  public String toString() {
+    return "VersionSupported{" + "min='" + min + '\'' + ", max='" + max + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    VersionSupported that = (VersionSupported) o;
+    return Objects.equals(min, that.min) && Objects.equals(max, that.max);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(min, max);
+  }
+}

--- a/src/main/java/io/gatling/plugin/model/Versions.java
+++ b/src/main/java/io/gatling/plugin/model/Versions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+public class Versions {
+
+  public final VersionSupported java;
+
+  @JsonCreator
+  public Versions(@JsonProperty(value = "java", required = true) VersionSupported java) {
+    this.java = java;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Versions versions = (Versions) o;
+    return Objects.equals(java, versions.java);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(java);
+  }
+
+  @Override
+  public String toString() {
+    return "Versions{" + "java=" + java + '}';
+  }
+}

--- a/src/test/java/io/gatling/plugin/model/JsonUnmarshallingTest.java
+++ b/src/test/java/io/gatling/plugin/model/JsonUnmarshallingTest.java
@@ -128,4 +128,13 @@ public class JsonUnmarshallingTest {
             "/#/simulations/reports/34c8716e-00bd-48dc-a28d-0568e9aa9622");
     assertEquals(expected, actual);
   }
+
+  @Test
+  public void ServerInformation_unmarshall() throws JsonProcessingException {
+    final String json = "{\"versions\":{\"java\":{\"max\":\"17\"}}}";
+    final ServerInformation actual = JSON_MAPPER.readValue(json, ServerInformation.class);
+    final ServerInformation expected =
+        new ServerInformation(new Versions(new VersionSupported(null, "17")));
+    assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
**Motivation:**
Skip upload of package that will not be runnable on our injectors.

**Modifications:**
* Add client request for server information containing maximum supported java version
* Update scanner version giving maximum java version detected in file
* Update codebase accordingly, and compare server java version with detected one
* Throw UnsupportedJavaVersionException when not supported