### PR TITLE
chore: Remove jvm options

### DIFF
--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -150,7 +150,6 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
             teamId,
             className,
             pkgId,
-            /* jvmOptions */ null,
             DEFAULT_SYSTEM_PROPERTIES,
             /* ignoreGlobalProperties */ false,
             DEFAULT_TIME_WINDOW,

--- a/src/main/java/io/gatling/plugin/model/SimulationCreationPayload.java
+++ b/src/main/java/io/gatling/plugin/model/SimulationCreationPayload.java
@@ -38,7 +38,6 @@ public final class SimulationCreationPayload {
   @JsonSerialize(using = PkgIdJsonSerializer.class)
   public final UUID pkgId;
 
-  public final String jvmOptions;
   public final Map<String, String> systemProperties;
   public final boolean ignoreGlobalProperties;
   public final MeaningfulTimeWindow meaningfulTimeWindow;
@@ -51,7 +50,6 @@ public final class SimulationCreationPayload {
       UUID teamId,
       String className,
       UUID pkgId,
-      String jvmOptions,
       Map<String, String> systemProperties,
       boolean ignoreGlobalProperties,
       MeaningfulTimeWindow meaningfulTimeWindow,
@@ -70,7 +68,6 @@ public final class SimulationCreationPayload {
     this.teamId = teamId;
     this.className = className;
     this.pkgId = pkgId;
-    this.jvmOptions = jvmOptions;
     this.systemProperties = systemProperties;
     this.ignoreGlobalProperties = ignoreGlobalProperties;
     this.meaningfulTimeWindow = meaningfulTimeWindow;
@@ -91,7 +88,6 @@ public final class SimulationCreationPayload {
         && teamId.equals(that.teamId)
         && className.equals(that.className)
         && pkgId.equals(that.pkgId)
-        && Objects.equals(jvmOptions, that.jvmOptions)
         && systemProperties.equals(that.systemProperties)
         && meaningfulTimeWindow.equals(that.meaningfulTimeWindow)
         && hostsByPool.equals(that.hostsByPool);
@@ -104,7 +100,6 @@ public final class SimulationCreationPayload {
         teamId,
         className,
         pkgId,
-        jvmOptions,
         systemProperties,
         ignoreGlobalProperties,
         meaningfulTimeWindow,

--- a/src/test/java/io/gatling/plugin/model/JsonMarshallingTest.java
+++ b/src/test/java/io/gatling/plugin/model/JsonMarshallingTest.java
@@ -57,7 +57,6 @@ public class JsonMarshallingTest {
             UUID.fromString("2bc38879-6dd1-461d-a8fd-47df4991fd9b"),
             "my.package.MyGatlingSimulation",
             UUID.fromString("0cf26226-b261-4af6-a52a-1fec36f4394a"),
-            /* jvmOptions */ null,
             systemProperties,
             /* ignoreGlobalProperties */ false,
             new MeaningfulTimeWindow(5, 10),

--- a/src/test/java/io/gatling/plugin/model/JsonUnmarshallingTest.java
+++ b/src/test/java/io/gatling/plugin/model/JsonUnmarshallingTest.java
@@ -89,7 +89,7 @@ public class JsonUnmarshallingTest {
   @Test
   public void Simulations_unmarshall() throws JsonProcessingException {
     final String json =
-        "{\"data\":[{\"id\":\"92634bbd-a88b-4c45-8968-756055e19e5b\",\"teamId\":\"2bc38879-6dd1-461d-a8fd-47df4991fd9b\",\"name\":\"My Gatling Simulation\",\"className\":\"my.package.MyGatlingSimulation\",\"build\":{\"pkgId\":\"0cf26226-b261-4af6-a52a-1fec36f4394a\"},\"jvmOptions\":\"string\",\"systemProperties\":{},\"ignoreGlobalProperties\":true,\"meaningfulTimeWindow\":{\"rampUp\":0,\"rampDown\":0},\"hostsByPool\":{\"poolId\":{\"size\":0,\"weight\":0}},\"usePoolWeights\":true,\"usePoolDedicatedIps\":true}]}";
+        "{\"data\":[{\"id\":\"92634bbd-a88b-4c45-8968-756055e19e5b\",\"teamId\":\"2bc38879-6dd1-461d-a8fd-47df4991fd9b\",\"name\":\"My Gatling Simulation\",\"className\":\"my.package.MyGatlingSimulation\",\"build\":{\"pkgId\":\"0cf26226-b261-4af6-a52a-1fec36f4394a\"},\"systemProperties\":{},\"ignoreGlobalProperties\":true,\"meaningfulTimeWindow\":{\"rampUp\":0,\"rampDown\":0},\"hostsByPool\":{\"poolId\":{\"size\":0,\"weight\":0}},\"usePoolWeights\":true,\"usePoolDedicatedIps\":true}]}";
     final Simulations actual = JSON_MAPPER.readValue(json, Simulations.class);
     final Simulations expected =
         new Simulations(


### PR DESCRIPTION
Motivation;
- jvmOptions is no longer used in Gatling enterprise simulation

Modification:
- removed jvmOptions