### PR TITLE
feat: parse system properties as string, closes MISC-388

### DIFF
--- a/src/main/java/io/gatling/plugin/EnterprisePlugin.java
+++ b/src/main/java/io/gatling/plugin/EnterprisePlugin.java
@@ -42,6 +42,7 @@ public interface EnterprisePlugin extends AutoCloseable {
    *
    * @param simulationId Required
    * @param systemProperties Required, can be an empty map
+   * @param environmentVariables Required, can be an empty map
    * @param simulationClass Optional, override simulation configured class name for next run
    * @param file Required, Path to the packaged JAR file to upload and run
    * @throws SimulationNotFoundException if the simulationId does not exist
@@ -49,7 +50,11 @@ public interface EnterprisePlugin extends AutoCloseable {
    *     has not been discovered
    */
   SimulationStartResult uploadPackageAndStartSimulation(
-      UUID simulationId, Map<String, String> systemProperties, String simulationClass, File file)
+      UUID simulationId,
+      Map<String, String> systemProperties,
+      Map<String, String> environmentVariables,
+      String simulationClass,
+      File file)
       throws EnterprisePluginException;
 
   /**
@@ -60,7 +65,8 @@ public interface EnterprisePlugin extends AutoCloseable {
    * @param artifactId Required
    * @param simulationClass Optional
    * @param packageId Optional
-   * @param systemProperties Required, can be an empty Map
+   * @param systemProperties Required, can be an empty map
+   * @param environmentVariables Required, can be an empty map
    * @param file Required
    * @throws SimulationStartException if simulation start failed after creation
    * @throws SeveralTeamsFoundException if teamId is null and there's more than one team discovered
@@ -75,6 +81,7 @@ public interface EnterprisePlugin extends AutoCloseable {
       String simulationClass,
       UUID packageId,
       Map<String, String> systemProperties,
+      Map<String, String> environmentVariables,
       File file)
       throws EnterprisePluginException;
 }

--- a/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/EnterpriseClient.java
@@ -60,9 +60,13 @@ public interface EnterpriseClient extends AutoCloseable {
   /**
    * @param simulationId Required
    * @param systemProperties Required (can be an empty map)
+   * @param environmentVariables Required (can be an empty map)
    * @throws SimulationStartException when start failed for any reason
    */
-  RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties)
+  RunSummary startSimulation(
+      UUID simulationId,
+      Map<String, String> systemProperties,
+      Map<String, String> environmentVariables)
       throws EnterprisePluginException;
 
   /**

--- a/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/OkHttpEnterpriseClient.java
@@ -31,6 +31,7 @@ import okhttp3.*;
 public final class OkHttpEnterpriseClient implements EnterpriseClient {
 
   private static final Map<String, String> DEFAULT_SYSTEM_PROPERTIES = Collections.emptyMap();
+  private static final Map<String, String> DEFAULT_ENVIRONMENT_VARIABLES = Collections.emptyMap();
   private static final MeaningfulTimeWindow DEFAULT_TIME_WINDOW = new MeaningfulTimeWindow(0, 0);
 
   private final OkHttpClient okHttpClient;
@@ -105,10 +106,13 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
   }
 
   @Override
-  public RunSummary startSimulation(UUID simulationId, Map<String, String> systemProperties)
+  public RunSummary startSimulation(
+      UUID simulationId,
+      Map<String, String> systemProperties,
+      Map<String, String> environmentVariables)
       throws EnterprisePluginException {
 
-    final StartOptions options = new StartOptions(systemProperties);
+    final StartOptions options = new StartOptions(systemProperties, environmentVariables);
 
     return simulationsApiRequests.startSimulation(simulationId, options);
   }
@@ -152,6 +156,7 @@ public final class OkHttpEnterpriseClient implements EnterpriseClient {
             pkgId,
             /* jvmOptions */ null,
             DEFAULT_SYSTEM_PROPERTIES,
+            DEFAULT_ENVIRONMENT_VARIABLES,
             /* ignoreGlobalProperties */ false,
             DEFAULT_TIME_WINDOW,
             hostsByPool,

--- a/src/main/java/io/gatling/plugin/model/SimulationCreationPayload.java
+++ b/src/main/java/io/gatling/plugin/model/SimulationCreationPayload.java
@@ -40,6 +40,7 @@ public final class SimulationCreationPayload {
 
   public final String jvmOptions;
   public final Map<String, String> systemProperties;
+  public final Map<String, String> environmentVariables;
   public final boolean ignoreGlobalProperties;
   public final MeaningfulTimeWindow meaningfulTimeWindow;
   public final Map<UUID, HostByPool> hostsByPool;
@@ -53,6 +54,7 @@ public final class SimulationCreationPayload {
       UUID pkgId,
       String jvmOptions,
       Map<String, String> systemProperties,
+      Map<String, String> environmentVariables,
       boolean ignoreGlobalProperties,
       MeaningfulTimeWindow meaningfulTimeWindow,
       Map<UUID, HostByPool> hostsByPool,
@@ -63,6 +65,7 @@ public final class SimulationCreationPayload {
     nonNullParam(className, "className");
     nonNullParam(pkgId, "pkgId");
     nonNullParam(systemProperties, "systemProperties");
+    nonNullParam(environmentVariables, "environmentVariables");
     nonNullParam(meaningfulTimeWindow, "meaningfulTimeWindow");
     nonNullParam(hostsByPool, "hostsByPool");
 
@@ -72,6 +75,7 @@ public final class SimulationCreationPayload {
     this.pkgId = pkgId;
     this.jvmOptions = jvmOptions;
     this.systemProperties = systemProperties;
+    this.environmentVariables = environmentVariables;
     this.ignoreGlobalProperties = ignoreGlobalProperties;
     this.meaningfulTimeWindow = meaningfulTimeWindow;
     this.hostsByPool = hostsByPool;
@@ -93,6 +97,7 @@ public final class SimulationCreationPayload {
         && pkgId.equals(that.pkgId)
         && Objects.equals(jvmOptions, that.jvmOptions)
         && systemProperties.equals(that.systemProperties)
+        && environmentVariables.equals(that.environmentVariables)
         && meaningfulTimeWindow.equals(that.meaningfulTimeWindow)
         && hostsByPool.equals(that.hostsByPool);
   }
@@ -106,6 +111,7 @@ public final class SimulationCreationPayload {
         pkgId,
         jvmOptions,
         systemProperties,
+        environmentVariables,
         ignoreGlobalProperties,
         meaningfulTimeWindow,
         hostsByPool,

--- a/src/main/java/io/gatling/plugin/model/StartOptions.java
+++ b/src/main/java/io/gatling/plugin/model/StartOptions.java
@@ -26,22 +26,36 @@ import java.util.Objects;
 public class StartOptions {
 
   public final Map<String, String> extraSystemProperties;
+  public final Map<String, String> extraEnvironmentVariables;
 
   @JsonCreator
   public StartOptions(
       @JsonProperty(value = "extraSystemProperties", required = true)
-          Map<String, String> extraSystemProperties) {
+          Map<String, String> extraSystemProperties,
+      @JsonProperty(value = "extraEnvironmentVariables", required = true)
+          Map<String, String> extraEnvironmentVariables) {
     nonNullParam(extraSystemProperties, "extraSystemProperties");
+    nonNullParam(extraEnvironmentVariables, "extraEnvironmentVariables");
     this.extraSystemProperties = extraSystemProperties;
+    this.extraEnvironmentVariables = extraEnvironmentVariables;
   }
 
   public Map<String, String> getExtraSystemProperties() {
     return extraSystemProperties;
   }
 
+  public Map<String, String> getExtraEnvironmentVariables() {
+    return extraEnvironmentVariables;
+  }
+
   @Override
   public String toString() {
-    return "StartOptions{" + "extraSystemProperties=" + extraSystemProperties + '}';
+    return "StartOptions{"
+        + "extraSystemProperties="
+        + extraSystemProperties
+        + ", extraEnvironmentVariables="
+        + extraEnvironmentVariables
+        + '}';
   }
 
   @Override
@@ -49,11 +63,12 @@ public class StartOptions {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     StartOptions that = (StartOptions) o;
-    return Objects.equals(extraSystemProperties, that.extraSystemProperties);
+    return Objects.equals(extraSystemProperties, that.extraSystemProperties)
+        && Objects.equals(extraEnvironmentVariables, that.extraEnvironmentVariables);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(extraSystemProperties);
+    return Objects.hash(extraSystemProperties, extraEnvironmentVariables);
   }
 }

--- a/src/main/java/io/gatling/plugin/util/PropertiesParserUtil.java
+++ b/src/main/java/io/gatling/plugin/util/PropertiesParserUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class PropertiesParserUtil {
+  private PropertiesParserUtil() {}
+
+  /**
+   * Parse a String following the format key1=value1,key2=value2 into a map
+   *
+   * @param properties the properties map
+   * @return The map containing the properties, minus malformed properties
+   */
+  public static Map<String, String> parseProperties(String properties) {
+    if (properties == null) {
+      return Collections.emptyMap();
+    }
+    return Arrays.stream(properties.split(","))
+        .map(property -> property.split("=", 2))
+        .filter(property -> property.length == 2)
+        .collect(
+            Collectors.toMap(
+                property -> {
+                  String key = property[0].trim();
+                  if (key.matches(".*\\s.*")) {
+                    throw new IllegalArgumentException(
+                        "A property key cannot contain whitespaces, invalid property: " + key);
+                  }
+                  return key;
+                },
+                property -> property[1].trim()));
+  }
+}

--- a/src/test/java/io/gatling/plugin/model/JsonMarshallingTest.java
+++ b/src/test/java/io/gatling/plugin/model/JsonMarshallingTest.java
@@ -48,6 +48,9 @@ public class JsonMarshallingTest {
     final Map<String, String> systemProperties = new HashMap<>();
     systemProperties.put("key_1", "First Value");
     systemProperties.put("key_2", "Second Value");
+    final Map<String, String> environmentVariables = new HashMap<>();
+    environmentVariables.put("keyA", "valueA");
+    environmentVariables.put("keyB", "valueB");
     final Map<UUID, HostByPool> hostsByPool = new HashMap<>();
     hostsByPool.put(UUID.fromString("b2a567f7-07f1-4de7-857a-2e0450b73377"), new HostByPool(1, 25));
     hostsByPool.put(UUID.fromString("43d47d5e-86c3-4918-b047-caf7fb1f1f71"), new HostByPool(2, 75));
@@ -59,6 +62,7 @@ public class JsonMarshallingTest {
             UUID.fromString("0cf26226-b261-4af6-a52a-1fec36f4394a"),
             /* jvmOptions */ null,
             systemProperties,
+            environmentVariables,
             /* ignoreGlobalProperties */ false,
             new MeaningfulTimeWindow(5, 10),
             hostsByPool,
@@ -66,7 +70,7 @@ public class JsonMarshallingTest {
             /* usePoolDedicatedIps */ false);
     final String actual = JSON_MAPPER.writeValueAsString(simulation);
     final String expected =
-        "{\"name\":\"My Gatling Simulation\",\"teamId\":\"2bc38879-6dd1-461d-a8fd-47df4991fd9b\",\"className\":\"my.package.MyGatlingSimulation\",\"systemProperties\":{\"key_2\":\"Second Value\",\"key_1\":\"First Value\"},\"ignoreGlobalProperties\":false,\"meaningfulTimeWindow\":{\"rampUp\":5,\"rampDown\":10},\"hostsByPool\":{\"b2a567f7-07f1-4de7-857a-2e0450b73377\":{\"size\":1,\"weight\":25},\"43d47d5e-86c3-4918-b047-caf7fb1f1f71\":{\"size\":2,\"weight\":75}},\"usePoolWeights\":true,\"usePoolDedicatedIps\":false,\"build\":{\"pkgId\":\"0cf26226-b261-4af6-a52a-1fec36f4394a\"}}";
+        "{\"name\":\"My Gatling Simulation\",\"teamId\":\"2bc38879-6dd1-461d-a8fd-47df4991fd9b\",\"className\":\"my.package.MyGatlingSimulation\",\"systemProperties\":{\"key_2\":\"Second Value\",\"key_1\":\"First Value\"},\"environmentVariables\":{\"keyA\":\"valueA\",\"keyB\":\"valueB\"},\"ignoreGlobalProperties\":false,\"meaningfulTimeWindow\":{\"rampUp\":5,\"rampDown\":10},\"hostsByPool\":{\"b2a567f7-07f1-4de7-857a-2e0450b73377\":{\"size\":1,\"weight\":25},\"43d47d5e-86c3-4918-b047-caf7fb1f1f71\":{\"size\":2,\"weight\":75}},\"usePoolWeights\":true,\"usePoolDedicatedIps\":false,\"build\":{\"pkgId\":\"0cf26226-b261-4af6-a52a-1fec36f4394a\"}}";
     assertEquals(expected, actual);
   }
 }

--- a/src/test/java/io/gatling/plugin/util/PropertiesParserUtilTest.java
+++ b/src/test/java/io/gatling/plugin/util/PropertiesParserUtilTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PropertiesParserUtilTest {
+  @Test
+  void parseProperties_ValidProperties() {
+    String properties = "key1=value1,key2=value2,key3=value3=value4=value5";
+    final Map<String, String> propertiesMap = new HashMap<>();
+    propertiesMap.put("key1", "value1");
+    propertiesMap.put("key2", "value2");
+    propertiesMap.put("key3", "value3=value4=value5");
+    assertEquals(propertiesMap, PropertiesParserUtil.parseProperties(properties));
+  }
+
+  @Test
+  void parseProperties_InvalidProperties() {
+    String properties = "Lorempsumdolorsitamet,consecteturadipiscingelit";
+    assertEquals(new HashMap<>(), PropertiesParserUtil.parseProperties(properties));
+  }
+
+  @Test
+  void parseProperties_SomeInvalidProperties() {
+    String properties = "consecteturadipiscing,key1=value1,key2=value2,Loremipsumdolorsitamet";
+    final Map<String, String> propertiesMap = new HashMap<>();
+    propertiesMap.put("key1", "value1");
+    propertiesMap.put("key2", "value2");
+    assertEquals(propertiesMap, PropertiesParserUtil.parseProperties(properties));
+  }
+
+  @Test
+  void parseProperties_WhitespaceKey() {
+    String properties = "key1 whitespace=value1,key2=value2,Loremipsumdolorsitamet";
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> PropertiesParserUtil.parseProperties(properties));
+    assertTrue(exception.getMessage().startsWith("A property key cannot contain whitespaces"));
+  }
+}


### PR DESCRIPTION
feat: Parse sytem properties as string, closes MISC-388

Motivation:
- multiple build plugins have trouble parsing system properties to a Map

Modifications:
- added a PropertiesParserUtil which parse a string of properties to a map
- following format is used: key1=value1,key2=value2

--------------

feat: Handle environment variables, closes MISC-368

Motivation:
- the public API allows passing extra env variables

Modifications:
- accepts env variables as a Map