### PR TITLE
fix: Handle building the base URL for the public API within the API client

### DIFF
--- a/src/main/java/io/gatling/plugin/client/http/HttpEnterpriseClient.java
+++ b/src/main/java/io/gatling/plugin/client/http/HttpEnterpriseClient.java
@@ -40,19 +40,27 @@ public final class HttpEnterpriseClient implements EnterpriseClient {
   private final SimulationsApiRequests simulationsApiRequests;
   private final TeamsApiRequests teamsApiRequests;
 
+  /**
+   * @param baseUrl Base URL for the Gatling Enterprise server, e.g. {@code
+   *     https://cloud.gatling.io}
+   * @param token Authentication token used to access the public API
+   * @param client Name of the calling client, used to verify if it is supported by the API
+   * @param version Version of the calling client, used to verify if it is supported by the API
+   */
   public HttpEnterpriseClient(URL baseUrl, String token, String client, String version)
       throws EnterprisePluginException {
     if (!"http".equals(baseUrl.getProtocol()) && !"https".equals(baseUrl.getProtocol())) {
       throw new InvalidBaseUrlException(baseUrl);
     }
+    final URL publicApiBaseUrl = ApiPath.of("api", "public").buildUrl(baseUrl);
 
-    infoApiRequests = new InfoApiRequests(baseUrl, token);
-    packagesApiRequests = new PackagesApiRequests(baseUrl, token);
-    poolsApiRequests = new PoolsApiRequests(baseUrl, token);
-    simulationsApiRequests = new SimulationsApiRequests(baseUrl, token);
-    teamsApiRequests = new TeamsApiRequests(baseUrl, token);
+    infoApiRequests = new InfoApiRequests(publicApiBaseUrl, token);
+    packagesApiRequests = new PackagesApiRequests(publicApiBaseUrl, token);
+    poolsApiRequests = new PoolsApiRequests(publicApiBaseUrl, token);
+    simulationsApiRequests = new SimulationsApiRequests(publicApiBaseUrl, token);
+    teamsApiRequests = new TeamsApiRequests(publicApiBaseUrl, token);
 
-    new PrivateApiRequests(baseUrl, token).checkVersionSupport(client, version);
+    new PrivateApiRequests(publicApiBaseUrl, token).checkVersionSupport(client, version);
   }
 
   @Override

--- a/src/test/java/io/gatling/plugin/client/http/HttpEnterpriseClientTest.java
+++ b/src/test/java/io/gatling/plugin/client/http/HttpEnterpriseClientTest.java
@@ -93,7 +93,7 @@ public class HttpEnterpriseClientTest {
         (server, client) -> {
           final ServerInformation response = client.getServerInformation();
           final RecordedRequest record = server.takeRequest(1, TimeUnit.SECONDS);
-          assertEquals("/info", record.getPath());
+          assertEquals("/api/public/info", record.getPath());
           assertEquals(AUTH_TOKEN, record.getHeader("Authorization"));
           assertEquals(expectedResponse, response);
           return null;
@@ -125,7 +125,7 @@ public class HttpEnterpriseClientTest {
         (server, client) -> {
           final List<PkgIndex> response = client.getPackages();
           final RecordedRequest record = server.takeRequest(1, TimeUnit.SECONDS);
-          assertEquals("/artifacts", record.getPath());
+          assertEquals("/api/public/artifacts", record.getPath());
           assertEquals(AUTH_TOKEN, record.getHeader("Authorization"));
           assertEquals(expectedResponse, response);
           return null;
@@ -149,7 +149,7 @@ public class HttpEnterpriseClientTest {
               client.createPackage(
                   "test package name", UUID.fromString("00000000-0000-0000-0000-200000000000"));
           final RecordedRequest record = server.takeRequest(1, TimeUnit.SECONDS);
-          assertEquals("/artifacts", record.getPath());
+          assertEquals("/api/public/artifacts", record.getPath());
           assertEquals(AUTH_TOKEN, record.getHeader("Authorization"));
           assertJsonEquals(expectedRequest, record.getBody().readUtf8());
           assertEquals(expectedResponse, response);
@@ -168,7 +168,10 @@ public class HttpEnterpriseClientTest {
           assertEquals(ARTIFACT_FILE.length(), Long.valueOf(record.getHeader("Content-Length")));
           assertEquals(ARTIFACT_FILE.length(), record.getBodySize());
           assertEquals(
-              "/artifacts/" + ARTIFACT_ID + "/content?filename=" + ARTIFACT_FILE.getName(),
+              "/api/public/artifacts/"
+                  + ARTIFACT_ID
+                  + "/content?filename="
+                  + ARTIFACT_FILE.getName(),
               record.getPath());
           return null;
         });


### PR DESCRIPTION
Motivation:
Currently, the build plugins provide a base URL which already includes the root path for the public API (e.g. 'https://cloud.gatling.io/api/public'). They don't handle trailing slashes properly when building this URL, and this doesn't have to be their responsibility anyway.

Modifications:
We now expect only the base URL to the Gatling Enterprise server (e.g 'https://cloud.gatling.io) when building the API client. Handle concatenating the '/api/public' base path internally.

Result:
Avoid duplicating (badly) this logic in each build plugin.