### PR TITLE
Drop commons-exec for forking processes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ lazy val root = (project in file("."))
       "net.aichler"                % "jupiter-interface"    % JupiterKeys.jupiterVersion.value % Test,
       "com.squareup.okhttp3"       % "mockwebserver"        % "4.9.3"                          % Test,
       "com.fasterxml.jackson.core" % "jackson-databind"     % "2.13.3",
-      "org.apache.commons"         % "commons-exec"         % "1.3",
       "io.gatling"                 % "gatling-scanner"      % "1.1.0"
     ),
     spotlessJava := JavaConfig(

--- a/src/main/java/io/gatling/plugin/util/Fork.java
+++ b/src/main/java/io/gatling/plugin/util/Fork.java
@@ -17,10 +17,7 @@
 package io.gatling.plugin.util;
 
 import io.gatling.plugin.io.PluginLogger;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -30,7 +27,6 @@ import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
-import org.apache.commons.exec.*;
 
 public final class Fork {
 
@@ -219,28 +215,18 @@ public final class Fork {
     this.jvmArgs.add(
         createBooterJar(classpath, MainWithArgsInFile.class.getName()).getCanonicalPath());
 
-    List<String> command = buildCommand();
+    Process process =
+        new ProcessBuilder(buildCommand()).directory(workingDirectory).inheritIO().start();
 
-    Executor exec = new DefaultExecutor();
-    exec.setStreamHandler(new PumpStreamHandler(System.out, System.err, System.in));
-    exec.setProcessDestroyer(new ShutdownHookProcessDestroyer());
-    if (workingDirectory != null) {
-      exec.setWorkingDirectory(workingDirectory);
-    }
-
-    CommandLine cl = new CommandLine(javaExecutable);
-    for (String arg : command) {
-      cl.addArgument(arg, false);
-    }
-
-    int exitValue = exec.execute(cl);
+    int exitValue = process.waitFor();
     if (exitValue != 0) {
       throw new IllegalStateException("command line returned non-zero value:" + exitValue);
     }
   }
 
   private List<String> buildCommand() throws IOException {
-    ArrayList<String> command = new ArrayList<>(jvmArgs.size() + 2);
+    ArrayList<String> command = new ArrayList<>(jvmArgs.size() + 3);
+    command.add(javaExecutable);
     command.addAll(jvmArgs);
     command.add(mainClassName);
     command.add(createArgFile(args).getCanonicalPath());

--- a/src/main/java/io/gatling/plugin/util/Fork.java
+++ b/src/main/java/io/gatling/plugin/util/Fork.java
@@ -217,7 +217,7 @@ public final class Fork {
 
     Process process =
         new ProcessBuilder(buildCommand()).directory(workingDirectory).inheritIO().start();
-
+    process.getOutputStream().close();
     int exitValue = process.waitFor();
     if (exitValue != 0) {
       throw new IllegalStateException("command line returned non-zero value:" + exitValue);


### PR DESCRIPTION
Motivation:

commons-exec is a legacy library and kind-off classpath dead weight (gatling-enterprise-plugin-commons is in the bundle’s runtime classpath, hence commons-exec is too). It's only there because the Fork class was forked from scala-maven-plugin to be compatible with pre-Java 7 world and it’s considered to be dropped there too.

Modification:

We can simply use ProcessBuilder instead.

Result:

* one less dependency, all the more a legacy one
* less dead weight in the bundle's classpath