### PR TITLE
Fix Java location, see gatling/gatling#4285

### DIFF
--- a/src/main/java/io/gatling/plugin/util/Fork.java
+++ b/src/main/java/io/gatling/plugin/util/Fork.java
@@ -42,7 +42,7 @@ public final class Fork {
   private static final String ARG_FILE_SUFFIX = ".args";
   private static final String GATLING_MANIFEST_VALUE = "GATLING_ZINC";
 
-  private final String javaExecutable;
+  private final File javaExecutable;
   private final String mainClassName;
   private final List<String> classpath;
   private final boolean propagateSystemProperties;
@@ -57,7 +57,7 @@ public final class Fork {
       List<String> classpath,
       List<String> jvmArgs,
       List<String> args,
-      String javaExecutable,
+      File javaExecutable,
       boolean propagateSystemProperties,
       PluginLogger log) {
 
@@ -77,7 +77,7 @@ public final class Fork {
       List<String> classpath,
       List<String> jvmArgs,
       List<String> args,
-      String javaExecutable,
+      File javaExecutable,
       boolean propagateSystemProperties,
       PluginLogger log,
       File workingDirectory) {
@@ -92,10 +92,8 @@ public final class Fork {
     this.workingDirectory = workingDirectory;
   }
 
-  public static boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("win");
-
-  private String toWindowsShortName(String value) {
-    if (IS_WINDOWS) {
+  public static String toWindowsShortName(String value) {
+    if (Os.IS_WINDOWS) {
       int programFilesIndex = value.indexOf("Program Files");
       if (programFilesIndex >= 0) {
         // Could be "Program Files" or "Program Files (x86)"
@@ -205,7 +203,7 @@ public final class Fork {
                     + name
                     + "' contains a whitespace and can't be propagated");
 
-          } else if (IS_WINDOWS && value.contains(" ")) {
+          } else if (Os.IS_WINDOWS && value.contains(" ")) {
             log.error(
                 "System property value '"
                     + value
@@ -234,7 +232,7 @@ public final class Fork {
 
   private List<String> buildCommand() throws IOException {
     ArrayList<String> command = new ArrayList<>(jvmArgs.size() + 3);
-    command.add(javaExecutable);
+    command.add(toWindowsShortName(javaExecutable.getCanonicalPath()));
     command.addAll(jvmArgs);
     command.add(mainClassName);
     command.add(createArgFile(args).getCanonicalPath());

--- a/src/main/java/io/gatling/plugin/util/JavaLocator.java
+++ b/src/main/java/io/gatling/plugin/util/JavaLocator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import java.io.File;
+
+public final class JavaLocator {
+  private JavaLocator() {}
+
+  // inspired from org.codehaus.plexus.compiler.javac.JavacCompiler#getJavacExecutable
+  public static File getJavaExecutable() {
+    String javaCommand = "java" + (Os.IS_WINDOWS ? ".exe" : "");
+
+    String javaHomeSystemProperty = System.getProperty("java.home");
+    if (javaHomeSystemProperty != null) {
+      if (javaHomeSystemProperty.endsWith(File.separator + "jre")) {
+        // Old JDK versions contain a JRE. We might be pointing to that.
+        // We want to try to use the JDK instead as we need javac in order to compile mixed
+        // Java-Scala projects.
+        File javaExec =
+            new File(
+                javaHomeSystemProperty + File.separator + ".." + File.separator + "bin",
+                javaCommand);
+        if (javaExec.isFile()) {
+          return javaExec;
+        }
+      }
+
+      // old standalone JRE or modern JDK
+      File javaExec = new File(javaHomeSystemProperty + File.separator + "bin", javaCommand);
+      if (javaExec.isFile()) {
+        return javaExec;
+      } else {
+        throw new IllegalStateException(
+            "Couldn't locate java in defined java.home system property.");
+      }
+    }
+
+    // fallback: try to resolve from JAVA_HOME
+    String javaHomeEnvVar = System.getenv("JAVA_HOME");
+    if (javaHomeEnvVar == null) {
+      throw new IllegalStateException(
+          "Couldn't locate java, try setting JAVA_HOME environment variable.");
+    }
+
+    File javaExec = new File(javaHomeEnvVar + File.separator + "bin", javaCommand);
+    if (javaExec.isFile()) {
+      return javaExec;
+    } else {
+      throw new IllegalStateException(
+          "Couldn't locate java in defined JAVA_HOME environment variable.");
+    }
+  }
+}

--- a/src/main/java/io/gatling/plugin/util/Os.java
+++ b/src/main/java/io/gatling/plugin/util/Os.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2011-2022 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gatling.plugin.util;
+
+import java.util.Locale;
+
+final class Os {
+
+  static final boolean IS_WINDOWS =
+      System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
+
+  private Os() {}
+}


### PR DESCRIPTION
Motivation:

gatling-maven-plugin and the bundle have to locate the java executable in order to spawn a forked process to run Gatling.
The current strategy is broken:
* it favors the JAVA_HOME env var over the launcher's JVM
* if JAVA_HOME is undefined and Java 8 is used, it will pick the JRE instead of the JDK, causing crashes when compiling Java code

This is the same issue as https://github.com/davidB/scala-maven-plugin/issues/619

Modification:

* Share Java location resolution is commons module.
* Favor current JVM over JAVA_HOME
* Favor JDK over JRE